### PR TITLE
Added edit & delete functionality

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -2,11 +2,49 @@ const pg = require('pg');
 const { validationResult } = require("express-validator");
 const { dbQuery } = require("../db/db-query");
 const { FLAGS_COL_NAMES } = require("../constants/db");
+const TABLE_NAME = "flags"
+const INVALID_UPDATE_MESSAGE = "No valid parameters passed to update";
 
-const createFlagInsertStatement = (newFlag) => {
+function getNowString() {
+  return new Date().toISOString();
+}
+
+const createInsertStatement = (newFlag) => {
   const columns = FLAGS_COL_NAMES.filter((col) => ![null, "", undefined].includes(newFlag[col]));
   const values = columns.map((col) => `'${newFlag[col]}'`);
-  return `INSERT INTO flags(${columns.join(", ")}) VALUES (${values.join(", ")})`
+  return `INSERT INTO ${TABLE_NAME}(${columns.join(", ")}) VALUES (${values.join(", ")}) RETURNING *`
+}
+
+const createUpdateStatement = (id, updatedFields) => {
+  const now = getNowString();
+  if (updatedFields.status !== undefined) updatedFields["last_toggle"] = now;
+
+  const edits = [];
+  Object.keys(updatedFields).forEach((fieldName) => {
+    if (FLAGS_COL_NAMES.includes(fieldName)) {
+      edits.push(`${fieldName} = '${updatedFields[fieldName]}'`);
+    }
+  });
+  if (edits.length === 0) throw new Error(INVALID_UPDATE_MESSAGE);
+  updatedFields["date_edited"] = now;
+
+  return `UPDATE ${TABLE_NAME} SET ${edits.join(", ")} WHERE id = ${id} RETURNING *`;
+}
+
+const createDeleteStatement = (id) => {
+  return `DELETE FROM ${TABLE_NAME} WHERE id = ${id} RETURNING *`;
+}
+
+const createNewFlagObj = ({ name, description, status }) => {
+  const now = getNowString();
+  return {
+    name: name,
+    description: description || "",
+    status: status || false,
+    date_created: now,
+    date_edited: now,
+    last_toggle: now,
+  }
 }
 
 const getAllFlags = async (req, res, next) => {
@@ -17,20 +55,12 @@ const getAllFlags = async (req, res, next) => {
 const createFlag = async (req, res, next) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
-    const today = new Date().toISOString()
-    const newFlag = {
-      name: req.body.name,
-      description: req.body.description || "",
-      status: req.body.status || false,
-      date_created: today,
-      date_edited: today,
-      last_toggle: today,
-    }
-
-    const queryString = createFlagInsertStatement(newFlag);
+    const newFlag = createNewFlagObj(req.body);
+    const queryString = createInsertStatement(newFlag);
     try {
       const result = await dbQuery(queryString);
-      res.status(200).send(newFlag);
+      const savedFlag = result.rows[0]
+      res.status(200).send(savedFlag);
     } catch (e) {
       res.status(500).send("Error inserting into flags table");
     }
@@ -39,12 +69,38 @@ const createFlag = async (req, res, next) => {
   }
 };
 
-const editFlag = (req, res, next) => {
-  res.send("editFlag");
+const editFlag = async (req, res, next) => {
+  const id = req.params.id;
+  try {
+    const queryString = createUpdateStatement(id, req.body);
+    const result = await dbQuery(queryString);
+    const updatedFlag = result.rows[0];
+    res.status(200).send(updatedFlag);
+  } catch (e) {
+    if (e.message === INVALID_UPDATE_MESSAGE) {
+      const errObj = {
+        message: INVALID_UPDATE_MESSAGE,
+        data: req.body
+      }
+      res.status(400).send(errObj);
+    } else {
+      res.status(500).send(e)
+    }
+  }
 };
 
-const deleteFlag = (req, res, next) => {
-  res.send("deleteFlag");
+const deleteFlag = async (req, res, next) => {
+  const id = req.params.id;
+  const queryString = createDeleteStatement(id);
+  try {
+    const result = await dbQuery(queryString);
+    if (result.rows.length === 0) throw new Error(`Flag with the id of ${id} doesn't exist`);
+
+    const deletedFlagName = result.rows[0].name;
+    res.status(200).send(`Flag '${deletedFlagName}' with id = ${id} successfully deleted`);
+  } catch (e) {
+    res.status(400).send(e.message)
+  }
 };
 
 exports.getAllFlags = getAllFlags;

--- a/server/validators/validators.js
+++ b/server/validators/validators.js
@@ -1,5 +1,7 @@
 const { check, oneOf } = require("express-validator");
+const { FLAGS_COL_NAMES } = require("../constants/db");
 
 exports.validateNewFlag = [check("name").not().isEmpty()];
-exports.validateEditFlag = [];
+// exports.validateEditFlag = [body(check("*").oneOf.FLAGS_COL_NAMES];
+// maybe do some schema validation https://express-validator.github.io/docs/schema-validation.html
 exports.validateSDKKey = [];


### PR DESCRIPTION
## Editing Flags
- You can now edit a FF by sending a PUT request supplying an object to the path '/api/flags/:id'
- The updated flag is returned
- You'll get an error message if there are no valid keys to update the flag with
- The 'date_edited' field is automatically updated
- You can use this path to toggle a flag, which'll update the 'status' of the flag as well as it's 'last_toggle'

## Deleting Flags
- You can delete a flag by sending a DELETE request to '/api/flags/:id'
- The deleted flag is returned
- If the flag you're trying to delete doesn't exist, an error will be returned

## Misc changes
- Wanted to implement a validator for the editFlag, but couldn't figure out how, so I just found a good resource and placed in *validators.js* and commented it out
- Added an error message as a constant
- Changed the table name to a constant

## Future work
- Move all constants to constants folder
- Move all query logic onto `pg` object in the *db* folder