### PR TITLE
Refactored API for better abstraction and general purpose

### DIFF
--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -1,2 +1,3 @@
-exports.FLAGS_COL_NAMES = ['id', 'app_id', 'name', 'description', 'status',
+exports.FLAG_FIELDS = ['id', 'app_id', 'name', 'description', 'status',
 'date_created', 'date_edited', 'last_toggle'];
+exports.FLAG_TABLE_NAME = "flags";

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -1,3 +1,1 @@
-exports.FLAG_FIELDS = ['id', 'app_id', 'name', 'description', 'status',
-'date_created', 'date_edited', 'last_toggle'];
 exports.FLAG_TABLE_NAME = "flags";

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -1,10 +1,11 @@
 const pg = require('pg');
 const { validationResult } = require("express-validator");
 const PGTable = require("../db/PGTable");
-const { FLAG_FIELDS, FLAG_TABLE_NAME } = require("../constants/db");
+const { FLAG_TABLE_NAME } = require("../constants/db");
 const { getNowString } = require("../utils");
 
-const flagTable = new PGTable(FLAG_TABLE_NAME, FLAG_FIELDS);
+const flagTable = new PGTable(FLAG_TABLE_NAME);
+flagTable.init();
 
 const createNewFlagObj = ({ name, description, status }) => {
   const now = getNowString();

--- a/server/db/PGTable.js
+++ b/server/db/PGTable.js
@@ -1,23 +1,62 @@
 const { dbQuery } = require("./db-query");
 // const bcrypt = require("bcrypt");
 
-module.exports = class Pg {
+module.exports =  class PGTable {
   // This is where we might add user data for logging purposes
   // constructor(session) {
   //   this.username = session.username;
   // }
-
-  async allFlags() {
-    const ALL_FLAGS = "SELECT * FROM flags;";
-    const resultFlags = await dbQuery(ALL_FLAGS);
-
-    const allFlags = resultFlags.rows;
-    if (!allFlags) {
-      throw new Error("Flags could not be retreived from postgres");
-    }
-
-    return allFlags;
+  constructor(tableName, fields) {
+    this.tableName = tableName;
+    this.fields = fields;
   }
+
+  createInsertStatement(newRow) {
+    const columns = this.fields.filter((col) => ![null, "", undefined].includes(newRow[col]));
+    const values = columns.map((col) => `'${newRow[col]}'`);
+    return `INSERT INTO ${this.tableName}(${columns.join(", ")}) VALUES (${values.join(", ")}) RETURNING *`
+  }
+
+  createUpdateStatement(id, updatedFields) {
+    const edits = [];
+    Object.keys(updatedFields).forEach((fieldName) => {
+      if (this.fields.includes(fieldName)) {
+        edits.push(`${fieldName} = '${updatedFields[fieldName]}'`);
+      }
+    });
+
+    return `UPDATE ${this.tableName} SET ${edits.join(", ")} WHERE id = ${id} RETURNING *`;
+  }
+
+  createDeleteStatement(id) {
+    return `DELETE FROM ${this.tableName} WHERE id = ${id} RETURNING *`;
+  }
+
+  async getAllRows() {
+    const statement = `SELECT * FROM ${this.tableName}`;
+    const result = await dbQuery(statement);
+    return result.rows;
+  }
+
+  async insertRow(obj) {
+    const queryString = this.createInsertStatement(obj);
+    const result = await dbQuery(queryString);
+    return result.rows[0]
+  };
+
+  async editRow(id, updatedFields) {
+    const queryString = this.createUpdateStatement(id, updatedFields);
+    console.log("query in editRow", queryString);
+    const result = await dbQuery(queryString);
+    return result.rows[0];
+  };
+
+  async deleteRow(id) {
+    const queryString = this.createDeleteStatement(id);
+    const result = await dbQuery(queryString);
+    return result;
+  };
+
 };
 
 // module.exports = class PgPersistence {

--- a/server/db/PGTable.js
+++ b/server/db/PGTable.js
@@ -6,9 +6,14 @@ module.exports =  class PGTable {
   // constructor(session) {
   //   this.username = session.username;
   // }
-  constructor(tableName, fields) {
+  constructor(tableName) {
     this.tableName = tableName;
-    this.fields = fields;
+    this.fields = [];
+  }
+
+  async init() {
+    this.fields = await this.getFields();
+    return this;
   }
 
   createInsertStatement(newRow) {
@@ -30,6 +35,12 @@ module.exports =  class PGTable {
 
   createDeleteStatement(id) {
     return `DELETE FROM ${this.tableName} WHERE id = ${id} RETURNING *`;
+  }
+
+  async getFields() {
+    const statement = `SELECT * FROM ${this.tableName} WHERE false`;
+    const result = await dbQuery(statement);
+    return result.fields.map(fieldObj => fieldObj.name);
   }
 
   async getAllRows() {

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,0 +1,3 @@
+exports.getNowString = () => {
+  return new Date().toISOString();
+}


### PR DESCRIPTION
1. Moved all querying logic from _flagsController.js_ to methods on an instance of `PGTable` (renamed from "Pg")
2. Initialized an instance of `PGTable` in _flagsController.js_ which is passed objects (or nothing if nothing required) that are gotten from `req.body`. This transformation logic still lives in _flagsController.js_, although it's been tweaked.
3. The `getNowString()` function that's used to create a string of the current time has been moved to a _utils.js_ file which'll house all miscellaneous utility functions.

Notes on the `PGTable` class:
- It's general purpose, so we should be able to use it for any table.
- It takes two arguments when initialized, the name of the table, and the fields (columns) of that table. This two arguments are saved as state and used to form querystrings.

Future work:
- Better validation and error handling