### PR TITLE
Validate unique flag name

### DIFF
--- a/client/src/components/EditFlagForm.jsx
+++ b/client/src/components/EditFlagForm.jsx
@@ -6,6 +6,7 @@ import { editFlag } from "../actions/flagActions";
 const EditFlagForm = ({ setIsEditing }) => {
   const dispatch = useDispatch();
   const { flagId } = useParams();
+  const flagNames = useSelector((state) => state.flags.map(flag => flag.name));
   const flagData = useSelector((state) =>
     state.flags.find((flag) => flag.id === +flagId)
   );
@@ -25,7 +26,11 @@ const EditFlagForm = ({ setIsEditing }) => {
       newPercent < 0 ||
       newPercent > 100
     ) {
-      window.alert("Please check your inputs again.");
+      alert("Please check your inputs again.");
+      return;
+    }
+    if (flagNames.includes(newName)) {
+      alert("Name is already taken by another feature flag.");
       return;
     }
 

--- a/client/src/components/EditFlagForm.jsx
+++ b/client/src/components/EditFlagForm.jsx
@@ -19,7 +19,8 @@ const EditFlagForm = ({ setIsEditing }) => {
     flagData ? flagData.percentage_split : 100
   );
 
-  const handleSaveEdits = () => {
+  const handleSaveEdits = (e) => {
+    e.preventDefault();
     if (
       newName.length === 0 ||
       isNaN(Number(newPercent)) ||
@@ -29,7 +30,7 @@ const EditFlagForm = ({ setIsEditing }) => {
       alert("Please check your inputs again.");
       return;
     }
-    if (flagNames.includes(newName)) {
+    if (flagNames.includes(newName) && newName !== flagData.name) {
       alert("Name is already taken by another feature flag.");
       return;
     }

--- a/client/src/components/NewFlagModal.jsx
+++ b/client/src/components/NewFlagModal.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { createFlag } from '../actions/flagActions';
 
 const NewFlagModal = ({ modalOpen, setModalOpen }) => {
   const dispatch = useDispatch();
+  const flags = useSelector(state => state.flags);
+  const flagNames = flags.map(flag => flag.name);
   const [ name, setName ] = useState('');
   const [ description, setDescription ] = useState('');
   const [ status, setStatus ] = useState(false);
@@ -24,6 +26,10 @@ const NewFlagModal = ({ modalOpen, setModalOpen }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (name.length === 0) return;
+    if (flagNames.includes(name)) {
+      alert("Name is already taken by another feature flag.");
+      return;
+    }
     dispatch(createFlag(name, description, status, percentage));
     resetForm();
   };
@@ -35,7 +41,7 @@ const NewFlagModal = ({ modalOpen, setModalOpen }) => {
         <h2 className="font-bold text-xl text-primary-violet">New Feature Flag</h2>
         <form className="new-flag-form">
           <div className="mt-2.5">
-            <label htmlFor="flag-title" className="mr-5">Name:</label>
+            <label htmlFor="flag-title" className="mr-5">Name (will be used as unique identifier):</label>
             <input id="flag-title" type="text" className="border border-primary-oxfordblue rounded-lg px-2" value={name} onChange={(e) => setName(e.target.value)} />
           </div>
           <div className="mt-2.5">


### PR DESCRIPTION
Makes sure the new flag name is unique for both the Create Flag form and the Edit Flag form, by checking if it is included in the list of existing flags' names.

One minor bug is that when the user enters a non-unique name on the Edit Flag form, the alert pops up correctly but then the page refreshes once the user clicks on it. Not sure why this is happening or how to fix it.