### PR TITLE
Create Experiment Form

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,6 +9,7 @@ import SideNav from './components/SideNav';
 import FlagDetailsPage from './components/FlagDetailsPage';
 import Header from './components/Header';
 import DBModal from './components/DBModal';
+import NewExperimentPage from './components/NewExperimentPage';
 
 function App() {
   const dispatch = useDispatch();
@@ -28,6 +29,7 @@ function App() {
           <Routes>
             <Route exact path="/" element={<FlagDashboard />} />
             <Route path="/flags/:flagId" element={<FlagDetailsPage />} />
+            <Route path="/flags/:flagId/create_experiment" element={<NewExperimentPage />} />
           </Routes>
         </BrowserRouter>
       </main>

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -19,3 +19,9 @@ export function createExperiment(exptObj) {
 export function createExperimentSuccess(newExpt) {
   return { type: "CREATE_EXPERIMENT_SUCCESS", newExpt };
 }
+
+export function editExperiment(exptId, updatedFields) {
+  return function(dispatch) {
+    apiClient.editExperiment(exptId, updatedFields);
+  }
+}

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -9,3 +9,13 @@ export function fetchExperiments(flagId) {
 export function fetchExperimentsSuccess(experiments) {
   return { type: "FETCH_EXPERIMENTS_SUCCESS", experiments };
 }
+
+export function createExperiment(exptObj) {
+  return function(dispatch) {
+    apiClient.createExperiment(exptObj, data => dispatch(createExperimentSuccess(data)));
+  }
+}
+
+export function createExperimentSuccess(newExpt) {
+  return { type: "CREATE_EXPERIMENT_SUCCESS", newExpt };
+}

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -2,7 +2,7 @@ import apiClient from '../lib/ApiClient';
 
 export function fetchExperiments(flagId) {
   return function(dispatch) {
-    apiClient.getExperiments(flagId, data => dispatch(fetchExperimentsSuccess(data)))
+    apiClient.fetchExperiments(flagId, data => dispatch(fetchExperimentsSuccess(data)))
   }
 }
 

--- a/client/src/actions/flagActions.js
+++ b/client/src/actions/flagActions.js
@@ -57,15 +57,6 @@ export function createFlagSuccess(flag) {
   return { type: "CREATE_FLAG_SUCCESS", flag };
 }
 
-export function toggleExperiment(flagId, status) {
-  return function(dispatch) {
-    apiClient.toggleExperiment(flagId, status, (data) => {
-      dispatch(editFlagSuccess(data));
-      dispatch(fetchExperiments(flagId));
-    });
-  }
-}
-
 export function editFlag(id, updatedFields) {
   return function(dispatch) {
     apiClient.editFlag(id, updatedFields, (data) => {

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchFlags, toggleFlag, toggleExperiment } from "../actions/flagActions";
-import { fetchExperiments } from "../actions/exptActions";
+import { fetchFlags, toggleFlag, editFlag } from "../actions/flagActions";
+import { fetchExperiments, editExperiment } from "../actions/exptActions";
 import { useParams, useNavigate } from "react-router-dom";
 import EditFlagForm from "./EditFlagForm";
 import ExperimentInfo from "./ExperimentInfo";
@@ -42,8 +42,11 @@ const FlagDetailsPage = () => {
     navigate(path);
   };
 
-  const handleStopExperiment = () => {
-    dispatch(toggleExperiment(flagId, false));
+  const handleStopExperiment = (e) => {
+    e.preventDefault();
+    const runningExptId = exptData.find(expt => expt.date_ended === null).id;
+    dispatch(editFlag(flagId, { is_experiment: false}));
+    dispatch(editExperiment(runningExptId, { date_ended: true}));
   };
 
   const handleToggle = (id) => {

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -2,12 +2,13 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchFlags, toggleFlag, toggleExperiment } from "../actions/flagActions";
 import { fetchExperiments } from "../actions/exptActions";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import EditFlagForm from "./EditFlagForm";
 import ExperimentInfo from "./ExperimentInfo";
 
 const FlagDetailsPage = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { flagId } = useParams();
   const flagData = useSelector((state) =>
     state.flags.find((flag) => flag.id === +flagId)
@@ -35,9 +36,10 @@ const FlagDetailsPage = () => {
     setIsEditing(true);
   };
 
-  const handleCreateExperiment = async (e) => {
-    await dispatch(toggleExperiment(flagId, true));
-    setExptsFetched(false);
+  const handleCreateExperiment = (e) => {
+    e.preventDefault();
+    let path = `/flags/${flagId}/create_experiment`;
+    navigate(path);
   };
 
   const handleStopExperiment = () => {

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -52,7 +52,7 @@ const FlagDetailsPage = () => {
     };
   };
 
-  if (!flagData) return null;
+  if (!flagData || !exptData) return null;
   return (
     <div className="py-5 px-8 w-full">
       <div className="flex justify-between items-center border-b border-b-primary-oxfordblue mb-5">

--- a/client/src/components/MetricCheckbox.jsx
+++ b/client/src/components/MetricCheckbox.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const MetricCheckbox = ({ name, id, selected, handleClick }) => {
+  const bgColor = selected ? "violet" : "offwhite";
+  const txtColor = selected ? "offwhite" : "black";
+  return (
+    <>
+      <input className="invisible" type="checkbox" name="metric" id={name} value={id} required />
+      <label onClick={handleClick} className={`border-2 border-black bg-primary-${bgColor} text-primary-${txtColor} font-bold rounded-lg py-1 px-2`} htmlFor={name}>
+        <div>{name}</div>
+      </label>
+    </>
+  )
+}
+
+export default MetricCheckbox;

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { editFlag } from "../actions/flagActions";
+
+const NewExperimentForm = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { flagId } = useParams();
+  // I lose this state upon refresh
+  const flagData = useSelector((state) =>
+    state.flags.find((flag) => flag.id === +flagId)
+  );
+  // const metrics = useSelector((state) => state.metrics);
+
+  const [duration, setDuration] = useState(14);
+  const [percentTest, setPercentTest] = useState(50);
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("");
+  const [metricIds, setMetricIds] = useState([]);
+
+  useEffect(() => {
+    // getMetrics data here, and update state if need be.
+    // is metrics data stored in state somewhere?
+  }, [])
+
+  const validPercent = (percent) => {
+    percent = Number(percent);
+    return percent >= 0 && percent <= 100 && !isNaN(percentTest) && Math.floor(percent) === percent;
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    let errMessage = ""
+    if (duration < 1) {
+      errMessage += "- The duration has to be at least one day\n"
+    }
+    if (validPercent) {
+      errMessage += "- The percentage you're testing has to be an integer between 0-100\n"
+    }
+
+    if (description.length > 255) {
+      errMessage += "- The length of the description is too long\n"
+    }
+
+    if (name.length > 50) {
+      errMessage += "- The length of the name is too long (max 50 char)\n"
+    }
+    if (errMessage.length > 0) {
+      alert(errMessage);
+      return;
+    }
+
+    const experimentObj = { name, flag_id: flagId, description, duration, metric_ids: metricIds };
+    const flagObj = { percentage_split: percentTest, is_experiment: true };
+
+    dispatch(editFlag(flagId, flagObj));
+    // dispatch(createExperiment()) need to create this first
+  };
+
+  const handleChangeMetrics = (e) => {
+    // do some sort of handling of check boxes
+    // if checking a metric, add the id to the metricIds
+    // if unchecking a metric, remove the id to the metricIds
+    // look into checkbox events
+  }
+
+  const handleCancel = (e) => {
+    e.preventDefault();
+    const path = `/flags/${flagId}`;
+    navigate(path);
+  }
+
+  return (
+    <form>
+      <div>
+        <label htmlFor="name" className="mr-2.5">
+          Name (optional):{" "}
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border border-primary-oxfordblue rounded-lg px-2"
+        />
+      </div>
+      <div className="mt-2.5">
+        <label htmlFor="description">Description (optional, max 255 characters): </label>
+        <textarea
+          id="description"
+          type="textarea"
+          rows="3"
+          cols="30"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="block border border-primary-oxfordblue rounded-lg px-2"
+        />
+      </div>
+      <div className="mt-2.5">
+        <label htmlFor="percent-test">Percent of Users Tested: </label>
+        <input
+          id="percent-test"
+          type="number"
+          max={100}
+          min={0}
+          size="3"
+          className="border border-primary-oxfordblue rounded-lg px-2"
+          value={percentTest}
+          onChange={(e) => setPercentTest(e.target.value)}
+        />{" "}
+        %
+        <p>{validPercent(percentTest) ? `(${100-percentTest}% of users in control group)` : "Please enter an integer from 0-100"}</p>
+      </div>
+      <div className="mt-2.5">
+        <label htmlFor="duration">Duration: </label>
+        <input
+          id="duration"
+          type="number"
+          min={0}
+          size="3"
+          className="border border-primary-oxfordblue rounded-lg px-2"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+        />{" "}
+        days
+      </div>
+      <div className="mt-2.5">
+        <label htmlFor="metrics">Metrics</label>
+        Will have some checkboxes for each metric here
+      </div>
+      <button className="btn bg-primary-turquoise" onClick={handleSubmit}>
+        Start New Experiment
+      </button>
+      <button className="btn bg-slate" onClick={handleCancel}>Cancel</button>
+    </form>
+  );
+};
+
+export default NewExperimentForm;

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { editFlag } from "../actions/flagActions";
 import { createExperiment } from "../actions/exptActions";
+import MetricCheckbox from "./MetricCheckbox";
 
 const NewExperimentForm = ({ metrics }) => {
   const dispatch = useDispatch();
@@ -13,7 +14,7 @@ const NewExperimentForm = ({ metrics }) => {
   const [percentTest, setPercentTest] = useState(50);
   const [name, setName] = useState("")
   const [description, setDescription] = useState("");
-  const [metricIds, setMetricIds] = useState([1, 2]);
+  const [metricIds, setMetricIds] = useState([]);
 
   const backToFlag = `/flags/${flagId}`;
 
@@ -65,11 +66,12 @@ const NewExperimentForm = ({ metrics }) => {
     navigate(backToFlag);
   };
 
-  const handleChangeMetrics = (e) => {
-    // do some sort of handling of check boxes
-    // if checking a metric, add the id to the metricIds
-    // if unchecking a metric, remove the id to the metricIds
-    // look into checkbox events
+  const toggleMetric = (id) => {
+    if (metricIds.includes(id)) {
+      setMetricIds(metricIds.filter(existingId => existingId !== id))
+    } else {
+      setMetricIds([...metricIds, id]);
+    }
   }
 
   const handleCancel = (e) => {
@@ -79,7 +81,7 @@ const NewExperimentForm = ({ metrics }) => {
 
   return (
     <form>
-      <div>
+      <div className="mt-2.5">
         <label htmlFor="name" className="mr-2.5">
           Name (optional):{" "}
         </label>
@@ -130,12 +132,13 @@ const NewExperimentForm = ({ metrics }) => {
         />{" "}
         days
       </div>
-      <div className="mt-2.5">
-        <label htmlFor="metrics">Metrics</label>
-        <input type="checkbox" name="metric" id="clicks" value="Clicks" required />
-        <label for="clicks">
-          <div>Clicks</div>
-        </label>
+      <div id="metrics">
+        <h3 className="mt-2.5 font-bold text-base">Click the metrics you want to measure</h3>
+        <div className="flex mt-2.5 justify-start">
+        {metrics.map(({ name, id }) => (
+          <MetricCheckbox key={id} name={name} id={id} handleClick={() => toggleMetric(id)} selected={metricIds.includes(id)}/>
+        ))}
+        </div>
       </div>
       <button className="btn bg-primary-turquoise" onClick={handleSubmit}>
         Start New Experiment

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -19,24 +19,24 @@ const NewExperimentForm = ({ metrics }) => {
   const backToFlag = `/flags/${flagId}`;
 
   const validPercent = (percent) => {
+    if (percent === "e") return false;
     percent = Number(percent);
-    return percent >= 0 && percent <= 100 && !isNaN(percentTest) && Math.floor(percent) === percent;
+    const result = percent >= 0 && percent <= 100 && !isNaN(percentTest) && Math.floor(percent) === percent;
+    return result
   }
 
   const validMetrics = (metricIds) => {
     const existingMetricIds = metrics.map((metric) => metric.id);
-    console.log("existingMetricIds", existingMetricIds);
-    console.log(metricIds);
-    console.log(typeof metricIds[0]);
     return metricIds.every(id => existingMetricIds.includes(id));
   }
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    let errMessage = ""
+  const validateInput = () => {
+    let errMessage = "";
+
     if (duration < 1) {
       errMessage += "- The duration has to be at least one day\n"
     }
+
     if (!validPercent(percentTest)) {
       errMessage += "- The percentage you're testing has to be an integer between 0-100\n"
     }
@@ -50,9 +50,20 @@ const NewExperimentForm = ({ metrics }) => {
     }
 
     if (!validMetrics(metricIds)) {
-      // maybe edit this error message to something better
-      errMessage += "- Please check to make sure your metrics are saved on the metrics page\n"
+      errMessage += "- Please check metrics page to make sure those you selected still exist\n"
     }
+
+    if (metricIds.length === 0) {
+      errMessage += "- Please select at least one metric. If your desired ones aren't present please visit the 'Metrics' tab and add them before starting the experiment\n"
+    }
+
+    return errMessage
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    let errMessage = validateInput();
+
     if (errMessage.length > 0) {
       alert(errMessage);
       return;
@@ -133,7 +144,7 @@ const NewExperimentForm = ({ metrics }) => {
         days
       </div>
       <div id="metrics">
-        <h3 className="mt-2.5 font-bold text-base">Click the metrics you want to measure</h3>
+        <h3 className="mt-2.5 font-bold text-base">Select the metrics you want to measure</h3>
         <div className="flex mt-2.5 justify-start">
         {metrics.map(({ name, id }) => (
           <MetricCheckbox key={id} name={name} id={id} handleClick={() => toggleMetric(id)} selected={metricIds.includes(id)}/>

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -132,7 +132,10 @@ const NewExperimentForm = ({ metrics }) => {
       </div>
       <div className="mt-2.5">
         <label htmlFor="metrics">Metrics</label>
-        Will have some checkboxes for each metric here
+        <input type="checkbox" name="metric" id="clicks" value="Clicks" required />
+        <label for="clicks">
+          <div>Clicks</div>
+        </label>
       </div>
       <button className="btn bg-primary-turquoise" onClick={handleSubmit}>
         Start New Experiment

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -6,18 +6,13 @@ import { editFlag } from "../actions/flagActions";
 const NewExperimentForm = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { flagId } = useParams();
-  // I lose this state upon refresh
-  const flagData = useSelector((state) =>
-    state.flags.find((flag) => flag.id === +flagId)
-  );
-  // const metrics = useSelector((state) => state.metrics);
+  const flagId = useParams();
 
   const [duration, setDuration] = useState(14);
   const [percentTest, setPercentTest] = useState(50);
   const [name, setName] = useState("")
   const [description, setDescription] = useState("");
-  const [metricIds, setMetricIds] = useState([]);
+  const [metricIds, setMetricIds] = useState([1, 2]);
 
   useEffect(() => {
     // getMetrics data here, and update state if need be.

--- a/client/src/components/NewExperimentForm.jsx
+++ b/client/src/components/NewExperimentForm.jsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { editFlag } from "../actions/flagActions";
+import { createExperiment } from "../actions/exptActions";
 
-const NewExperimentForm = () => {
+const NewExperimentForm = ({ metrics }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const flagId = useParams();
+  const { flagId } = useParams();
 
   const [duration, setDuration] = useState(14);
   const [percentTest, setPercentTest] = useState(50);
@@ -14,14 +15,19 @@ const NewExperimentForm = () => {
   const [description, setDescription] = useState("");
   const [metricIds, setMetricIds] = useState([1, 2]);
 
-  useEffect(() => {
-    // getMetrics data here, and update state if need be.
-    // is metrics data stored in state somewhere?
-  }, [])
+  const backToFlag = `/flags/${flagId}`;
 
   const validPercent = (percent) => {
     percent = Number(percent);
     return percent >= 0 && percent <= 100 && !isNaN(percentTest) && Math.floor(percent) === percent;
+  }
+
+  const validMetrics = (metricIds) => {
+    const existingMetricIds = metrics.map((metric) => metric.id);
+    console.log("existingMetricIds", existingMetricIds);
+    console.log(metricIds);
+    console.log(typeof metricIds[0]);
+    return metricIds.every(id => existingMetricIds.includes(id));
   }
 
   const handleSubmit = (e) => {
@@ -30,7 +36,7 @@ const NewExperimentForm = () => {
     if (duration < 1) {
       errMessage += "- The duration has to be at least one day\n"
     }
-    if (validPercent) {
+    if (!validPercent(percentTest)) {
       errMessage += "- The percentage you're testing has to be an integer between 0-100\n"
     }
 
@@ -41,16 +47,22 @@ const NewExperimentForm = () => {
     if (name.length > 50) {
       errMessage += "- The length of the name is too long (max 50 char)\n"
     }
+
+    if (!validMetrics(metricIds)) {
+      // maybe edit this error message to something better
+      errMessage += "- Please check to make sure your metrics are saved on the metrics page\n"
+    }
     if (errMessage.length > 0) {
       alert(errMessage);
       return;
     }
 
-    const experimentObj = { name, flag_id: flagId, description, duration, metric_ids: metricIds };
+    const exptObj = { name, flag_id: flagId, description, duration, metric_ids: metricIds };
     const flagObj = { percentage_split: percentTest, is_experiment: true };
 
     dispatch(editFlag(flagId, flagObj));
-    // dispatch(createExperiment()) need to create this first
+    dispatch(createExperiment(exptObj));
+    navigate(backToFlag);
   };
 
   const handleChangeMetrics = (e) => {
@@ -62,8 +74,7 @@ const NewExperimentForm = () => {
 
   const handleCancel = (e) => {
     e.preventDefault();
-    const path = `/flags/${flagId}`;
-    navigate(path);
+    navigate(backToFlag);
   }
 
   return (

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -35,8 +35,8 @@ const NewExperimentPage = () => {
   if (!flagData) return null;
   // if (!flagData || !metrics) return null;
   return (
-    <div>
-      <h1>Create an Experiment</h1>
+    <div className="ml-5 mt-5">
+      <h1 className="text-xl font-bold text-primary-oxfordblue">Create an Experiment</h1>
       <h3>This experiment will be on <strong>{`${flagData.name}`}</strong></h3>
       <NewExperimentForm metrics={metrics}/>
     </div>

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
+import { fetchFlags } from "../actions/flagActions";
 import NewExperimentForm from './NewExperimentForm';
 
 const NewExperimentPage = () => {
@@ -9,7 +10,16 @@ const NewExperimentPage = () => {
   const flagData = useSelector((state) =>
     state.flags.find((flag) => flag.id === +flagId)
   );
+  const [flagFetched, setFlagFetched] = useState(false);
 
+  useEffect(() => {
+    if (!flagFetched) {
+      dispatch(fetchFlags());
+      setFlagFetched(true);
+    }
+  }, [dispatch, flagId, flagFetched]);
+
+  if (!flagData) return null;
   return (
     <div>
       <h1>Create an Experiment</h1>

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -11,6 +11,12 @@ const NewExperimentPage = () => {
     state.flags.find((flag) => flag.id === +flagId)
   );
   const [flagFetched, setFlagFetched] = useState(false);
+  // const metrics = useSelector((metrics) => state.metrics);
+  // const [metricsFetched, setMetricsFetched] = useState(false);
+  const metrics = [
+    { id: 1, name: "Created Account", query_string: "", type: "binomial"},
+    { id: 2, name: "Time on site", query_string: "", type: "count"}
+  ]
 
   useEffect(() => {
     if (!flagFetched) {
@@ -19,12 +25,20 @@ const NewExperimentPage = () => {
     }
   }, [dispatch, flagId, flagFetched]);
 
+  // useEffect(() => {
+  //   if (!metricsFetched) {
+  //     dispatch(fetchMetrics());
+  //     setMetricsFetched(true);
+  //   }
+  // }, [dispatch, metrics, metricsFetched]);
+
   if (!flagData) return null;
+  // if (!flagData || !metrics) return null;
   return (
     <div>
       <h1>Create an Experiment</h1>
       <h3>This experiment will be on <strong>{`${flagData.name}`}</strong></h3>
-      <NewExperimentForm />
+      <NewExperimentForm metrics={metrics}/>
     </div>
   );
 };

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -35,7 +35,7 @@ const NewExperimentPage = () => {
   if (!flagData) return null;
   // if (!flagData || !metrics) return null;
   return (
-    <div className="ml-5 mt-5">
+    <div className="ml-5 mt-5 w-full">
       <h1 className="text-xl font-bold text-primary-oxfordblue">Create an Experiment</h1>
       <h3>This experiment will be on <strong>{`${flagData.name}`}</strong></h3>
       <NewExperimentForm metrics={metrics}/>

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import NewExperimentForm from './NewExperimentForm';
+
+const NewExperimentPage = () => {
+  const dispatch = useDispatch();
+  const { flagId } = useParams();
+  const flagData = useSelector((state) =>
+    state.flags.find((flag) => flag.id === +flagId)
+  );
+
+  return (
+    <div>
+      <h1>Create an Experiment</h1>
+      <h3>This experiment will be on <strong>{`${flagData.name}`}</strong></h3>
+      <NewExperimentForm />
+    </div>
+  );
+};
+
+export default NewExperimentPage;

--- a/client/src/lib/ApiClient.js
+++ b/client/src/lib/ApiClient.js
@@ -111,9 +111,16 @@ const apiClient = {
       .then(callback)
       .catch(logError)
   },
-  getExperiment: function(flagId, callback) {
+  getExperiment: function(id, callback) {
     return axios
-      .get(`/api/flags/${flagId}/experiment`)
+      .get(`/api/experiments/${id}`)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError)
+  },
+  fetchExperiments: function(flagId, callback) {
+    return axios
+      .get(`/api/flags/${flagId}/experiments`)
       .then(unwrapData)
       .then(callback)
       .catch(logError)

--- a/client/src/lib/ApiClient.js
+++ b/client/src/lib/ApiClient.js
@@ -97,6 +97,27 @@ const apiClient = {
       .then(callback)
       .catch(logError)
   },
+  createExperiment: function(obj, callback) {
+    return axios
+      .post('/api/experiments', obj)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError)
+  },
+  editExperiment: function(id, obj, callback) {
+    return axios
+      .put(`/api/experiments/${id}`, obj)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError)
+  },
+  getExperiment: function(flagId, callback) {
+    return axios
+      .get(`/api/flags/${flagId}/experiment`)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError)
+  }
 };
 
 export default apiClient;

--- a/client/src/lib/ApiClient.js
+++ b/client/src/lib/ApiClient.js
@@ -62,13 +62,6 @@ const apiClient = {
       .then(callback)
       .catch(logError);
   },
-  toggleExperiment: function(id, status, callback) {
-    return axios
-      .put(`/api/flags/${id}`, { is_experiment: status })
-      .then(unwrapData)
-      .then(callback)
-      .catch(logError);
-  },
   getExperiments: function(id, callback) {
     return axios
       .get(`/api/experiments/${id}`)

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -3,6 +3,9 @@ export default function experiments(state = [], action) {
     case "FETCH_EXPERIMENTS_SUCCESS": {
       return action.experiments;
     }
+    case "CREATE_EXPERIMENT_SUCCESS": {
+      return [...state, action.newExpt];
+    }
     default: {
       return state;
     }


### PR DESCRIPTION
You can now create an experiment using a form. To reach the form, click on a flag from the flag dashboard, then click "Create Experiment." Enter in your data and then click "Start New Experiment" and it'll take you back to the flag page and the experiment stuff will be updated.

As of right now I'm using dummy data for the metrics, that I input into the `NewExperimentForm` component. I figured I'd get your guy's feedback and correct stuff now and then I'll implement that new change in the next pull request.

There is also no UI change on the flag details page to reflect the extra fields that it receives from the "api/flags/:flagId/experiments" request, those will come in a future pull request.

List of changes:
- Added a route for the create_experiment path in App.js
- Added `createExperiment` and `editExperiment` action creators
- Deleted the `toggleExperiment` action creator from the flag actions
- Changed how `handleCreateExperiment` and `handleStopExperiment` work in _FlagDetailsPage_ so that they use the new action creators
- Created `NewExperimentForm`, `NewExperimentPage`, and `MetricCheckbox` to implement the new experiment form.
- Created input validation to `NewExperimentForm`
- Created `createExperiment`, `editExperiment`, `getExperiment`, and `fetchExperiments` methods on ApiClient to grab experiment data from our API. Deleted the `toggleExperiment` method.