### PR TITLE
Expt UI improvements

### DIFF
--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -22,6 +22,12 @@ export function createExperimentSuccess(newExpt) {
 
 export function editExperiment(exptId, updatedFields) {
   return function(dispatch) {
-    apiClient.editExperiment(exptId, updatedFields);
+    apiClient.editExperiment(exptId, updatedFields, data => {
+      dispatch(editExperimentSuccess(data));
+    });
   }
+}
+
+export function editExperimentSuccess(editedExpt) {
+  return { type: "EDIT_EXPERIMENT_SUCCESS", editedExpt };
 }

--- a/client/src/components/EditExperiment.jsx
+++ b/client/src/components/EditExperiment.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import { editExperiment } from "../actions/exptActions";
+import { useDispatch } from "react-redux";
+
+
+const EditExperiment = ({ id, name, description, duration, date_started, date_ended, setIsEditing }) => {
+  const dispatch = useDispatch();
+  const [newName, setNewName] = useState(name);
+  const [newDescription, setNewDescription] = useState(description);
+  const [newDuration, setNewDuration] = useState(duration);
+  const inputCSS = "border border-primary-oxfordblue rounded-lg px-2";
+
+  const startDate = new Date(date_started).toLocaleDateString("en-US");
+
+  const submitEdits = (e) => {
+    e.preventDefault();
+    const edits = { name: newName, description: newDescription, duration: newDuration };
+    dispatch(editExperiment(id, edits));
+    setIsEditing(false);
+  }
+  return (
+    <>
+      <div className="flex justify-between items-center w-full">
+        <h2 className="text-primary-violet text-lg">Experiment from {startDate} to Present</h2>
+        <div className="flex justify-between items-center">
+          <button className="bg-primary-turquoise text-primary-offwhite rounded-lg py-1.5 px-6 ml-2" type="submit" onClick={submitEdits}>Submit</button>
+          <button className="bg-slate text-primary-offwhite rounded-lg py-1.5 px-6 ml-2" type="button" onClick={() => setIsEditing(false)}>Cancel</button>
+        </div>
+      </div>
+      <p>ID: <span className="font-bold">{id}</span></p>
+      <p>Name: <input className={inputCSS} value={newName} onChange={(e) => setNewName(e.target.value)}/></p>
+      <p>Duration: <input className={inputCSS} type="number" value={newDuration} onChange={(e) => setNewDuration(e.target.value)}/> days</p>
+      <p>Description: <input className={inputCSS} value={newDescription} onChange={(e) => setNewDescription(e.target.value)}/></p>
+    </>
+  )
+}
+
+export default EditExperiment;

--- a/client/src/components/EditExperiment.jsx
+++ b/client/src/components/EditExperiment.jsx
@@ -12,10 +12,44 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
 
   const startDate = new Date(date_started).toLocaleDateString("en-US");
 
+  const getChangedData = () => {
+    const edits = {}
+    if (newName !== name) edits.name = newName;
+    if (Number(newDuration) !== Number(duration)) edits.duration = newDuration;
+    if (newDescription !== description) edits.description = newDescription;
+    return edits;
+  }
+
+  const validateInput = () => {
+    let errMessage = "";
+
+    if (newDuration < 1) {
+      errMessage += "- The duration has to be at least one day\n"
+    }
+
+    if (description.length > 255) {
+      errMessage += "- The length of the description is too long\n"
+    }
+
+    if (name.length > 50) {
+      errMessage += "- The length of the name is too long (max 50 char)\n"
+    }
+
+    return errMessage
+  }
+
   const submitEdits = (e) => {
     e.preventDefault();
-    const edits = { name: newName, description: newDescription, duration: newDuration };
-    dispatch(editExperiment(id, edits));
+    const edits = getChangedData();
+    const errMessage = validateInput();
+    if (errMessage.length > 0) {
+      alert(errMessage);
+      return
+    }
+    
+    if (Object.keys(edits).length !== 0) {
+      dispatch(editExperiment(id, edits));
+    }
     setIsEditing(false);
   }
   return (
@@ -31,6 +65,7 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
       <p>Name: <input className={inputCSS} value={newName} onChange={(e) => setNewName(e.target.value)}/></p>
       <p>Duration: <input className={inputCSS} type="number" value={newDuration} onChange={(e) => setNewDuration(e.target.value)}/> days</p>
       <p>Description: <input className={inputCSS} value={newDescription} onChange={(e) => setNewDescription(e.target.value)}/></p>
+      <p className="text-primary-violet">Note: if you'd like to change the rollout of this experiment, edit the rollout of this flag by hitting the "Edit" button near the top of the page</p>
     </>
   )
 }

--- a/client/src/components/EditExperiment.jsx
+++ b/client/src/components/EditExperiment.jsx
@@ -5,8 +5,8 @@ import { useDispatch } from "react-redux";
 
 const EditExperiment = ({ id, name, description, duration, date_started, date_ended, setIsEditing }) => {
   const dispatch = useDispatch();
-  const [newName, setNewName] = useState(name);
-  const [newDescription, setNewDescription] = useState(description);
+  const [newName, setNewName] = useState(name || "");
+  const [newDescription, setNewDescription] = useState(description || "");
   const [newDuration, setNewDuration] = useState(duration);
   const inputCSS = "border border-primary-oxfordblue rounded-lg px-2";
 
@@ -27,11 +27,11 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
       errMessage += "- The duration has to be at least one day\n"
     }
 
-    if (description.length > 255) {
+    if (newDescription.length > 255) {
       errMessage += "- The length of the description is too long\n"
     }
 
-    if (name.length > 50) {
+    if (newName.length > 50) {
       errMessage += "- The length of the name is too long (max 50 char)\n"
     }
 
@@ -46,7 +46,7 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
       alert(errMessage);
       return
     }
-    
+
     if (Object.keys(edits).length !== 0) {
       dispatch(editExperiment(id, edits));
     }

--- a/client/src/components/ExperimentInfo.jsx
+++ b/client/src/components/ExperimentInfo.jsx
@@ -1,14 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
+import EditExperiment from "./EditExperiment";
 
-const ExperimentInfo = ({ id, date_started, date_ended }) => {
+const ExperimentInfo = ({ data }) => {
+  const { id, name, description, duration, date_started, date_ended } = data;
+  const [isEditing, setIsEditing] = useState(false);
   const startDate = new Date(date_started).toLocaleDateString("en-US");
   const endDate = date_ended ? new Date(date_ended).toLocaleDateString("en-US") : "Present";
 
   return (
     <div className="border border-dashed border-primary-oxfordblue rounded p-5 my-4">
-      <h2 className="text-primary-violet text-lg">Experiment from {startDate} to {endDate}</h2>
-      <p>This experiment's ID is: <span className="font-bold">{id}</span></p>
-      <p>Details about experiment, charts and stats go here</p>
+      {!isEditing ? (
+        <>
+          <div className="flex justify-between items-center w-full">
+            <h2 className="text-primary-violet text-lg">Experiment from {startDate} to {endDate}</h2>
+            {!date_ended && <button className="bg-primary-turquoise text-primary-offwhite rounded-lg py-1.5 px-6 ml-2" type="button" onClick={() => setIsEditing(true)}>Edit Experiment</button>}
+          </div>
+          <p>ID: <span className="font-bold">{id}</span></p>
+          <p>Name: <span className="font-bold">{name}</span></p>
+          <p>Duration: <span className="font-bold">{duration + " days"}</span></p>
+          <p>Description: <span className="font-bold">{description}</span></p>
+          <p>Details about experiment analysis, charts and stats go here</p>
+        </>
+    ) : (
+      <>
+        <EditExperiment setIsEditing={setIsEditing} {...data}/>
+      </>
+    )
+      }
+
     </div>
   );
 };

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -47,6 +47,7 @@ const FlagDetailsPage = () => {
     const runningExptId = exptData.find(expt => expt.date_ended === null).id;
     dispatch(editFlag(flagId, { is_experiment: false}));
     dispatch(editExperiment(runningExptId, { date_ended: true}));
+    setExptsFetched(false);
   };
 
   const handleToggle = (id) => {

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -121,7 +121,7 @@ const FlagDetailsPage = () => {
       )}
       {exptData &&
         exptData.map((expt) => {
-          return <ExperimentInfo key={expt.id} {...expt} />;
+          return <ExperimentInfo key={expt.id} data={expt} />;
         })}
     </div>
   );

--- a/client/src/components/NewExperimentPage.jsx
+++ b/client/src/components/NewExperimentPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchFlags } from "../actions/flagActions";
+import { fetchMetrics } from "../actions/metricActions";
 import NewExperimentForm from './NewExperimentForm';
 
 const NewExperimentPage = () => {
@@ -11,12 +12,8 @@ const NewExperimentPage = () => {
     state.flags.find((flag) => flag.id === +flagId)
   );
   const [flagFetched, setFlagFetched] = useState(false);
-  // const metrics = useSelector((metrics) => state.metrics);
-  // const [metricsFetched, setMetricsFetched] = useState(false);
-  const metrics = [
-    { id: 1, name: "Created Account", query_string: "", type: "binomial"},
-    { id: 2, name: "Time on site", query_string: "", type: "count"}
-  ]
+  const metrics = useSelector((state) => state.metrics);
+  const [metricsFetched, setMetricsFetched] = useState(false);
 
   useEffect(() => {
     if (!flagFetched) {
@@ -25,15 +22,14 @@ const NewExperimentPage = () => {
     }
   }, [dispatch, flagId, flagFetched]);
 
-  // useEffect(() => {
-  //   if (!metricsFetched) {
-  //     dispatch(fetchMetrics());
-  //     setMetricsFetched(true);
-  //   }
-  // }, [dispatch, metrics, metricsFetched]);
+  useEffect(() => {
+    if (!metricsFetched) {
+      dispatch(fetchMetrics());
+      setMetricsFetched(true);
+    }
+  }, [dispatch, metrics, metricsFetched]);
 
-  if (!flagData) return null;
-  // if (!flagData || !metrics) return null;
+  if (!flagData || !metrics) return null;
   return (
     <div className="ml-5 mt-5 w-full">
       <h1 className="text-xl font-bold text-primary-oxfordblue">Create an Experiment</h1>

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -6,6 +6,14 @@ export default function experiments(state = [], action) {
     case "CREATE_EXPERIMENT_SUCCESS": {
       return [...state, action.newExpt];
     }
+    case "EDIT_EXPERIMENT_SUCCESS": {
+      let newState = [...state];
+      const indexOfEdited = newState.findIndex((expt) => (
+        expt.id === action.editedExpt.id
+      ));
+      newState[indexOfEdited] = action.editedExpt;
+      return newState;
+    }
     default: {
       return state;
     }


### PR DESCRIPTION
The Create Experiment form now uses saved metric data from the DB to populate the metrics that are clickable.

You can edit a running experiment by clicking on an "Edit Experiment" button.

There are more details about the experiment shown on the FlagDetailsPage.

Clicking "stop experiment" now triggers a re-render of the page, thus updating the date_ended of the most recent running experiment and getting rid of the "edit experiment" button in the UI