### PR TITLE
User is able to create, edit, and delete metrics in the UI

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import MetricsPage from './components/MetricsPage';
 import Header from './components/Header';
 import DBModal from './components/DBModal';
 import NewExperimentPage from './components/NewExperimentPage';
+import NewMetricForm from './components/NewMetricForm';
 
 function App() {
   const dispatch = useDispatch();
@@ -32,6 +33,7 @@ function App() {
             <Route path="/flags/:flagId" element={<FlagDetailsPage />} />
             <Route path="/flags/:flagId/create_experiment" element={<NewExperimentPage />} />
             <Route path="/metrics" element={<MetricsPage />} />
+            <Route path="/edit_metric/:id" element={<NewMetricForm />} />
           </Routes>
         </BrowserRouter>
       </main>

--- a/client/src/actions/metricActions.js
+++ b/client/src/actions/metricActions.js
@@ -12,7 +12,14 @@ export function fetchMetricsSuccess(metrics) {
 
 export function editMetric(id, updatedFields) {
   return function(dispatch) {
-    apiClient.editMetric(id, updatedFields, data => dispatch(editMetricSuccess(data)));
+    return apiClient.editMetric(id, updatedFields, (data) => {
+      if (data.ok) {
+        dispatch(editMetricSuccess(data));
+        return true;
+      }
+      alert(`Editing metric failed: ${data.error_message}`);
+      return false;
+    });
   }
 }
 
@@ -32,7 +39,7 @@ export function deleteMetricSuccess(id) {
 
 export function createMetric(fields) {
   return function(dispatch) {
-    apiClient.createMetric(fields, (data) => {
+    return apiClient.createMetric(fields, (data) => {
       if (data.ok) {
         dispatch(createMetricSuccess(data.metric));
         return true;

--- a/client/src/actions/metricActions.js
+++ b/client/src/actions/metricActions.js
@@ -29,3 +29,13 @@ export function deleteMetric(id) {
 export function deleteMetricSuccess(id) {
   return { type: "DELETE_METRIC_SUCCESS", id: id };
 }
+
+export function createMetric(fields) {
+  return function(dispatch) {
+    apiClient.createMetric(fields, (data) => dispatch(createMetricSuccess(data)));
+  }
+}
+
+export function createMetricSuccess(metric) {
+  return { type: "CREATE_METRIC_SUCCESS", metric };
+}

--- a/client/src/actions/metricActions.js
+++ b/client/src/actions/metricActions.js
@@ -32,7 +32,14 @@ export function deleteMetricSuccess(id) {
 
 export function createMetric(fields) {
   return function(dispatch) {
-    apiClient.createMetric(fields, (data) => dispatch(createMetricSuccess(data)));
+    apiClient.createMetric(fields, (data) => {
+      if (data.ok) {
+        dispatch(createMetricSuccess(data.metric));
+        return true;
+      }
+      alert(`Creating metric failed: ${data.error_message}`);
+      return false;
+    });
   }
 }
 

--- a/client/src/components/MetricItem.jsx
+++ b/client/src/components/MetricItem.jsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React from "react";
+import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { deleteMetric } from '../actions/metricActions';
+import { deleteMetric } from "../actions/metricActions";
 
-const MetricsItem = ({ id, name, query_string, type, setIsEditing }) => {
+const MetricsItem = ({ id, name, query_string, type }) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const handleEditMetric = () => {
-    setIsEditing(true);
+    navigate(`/edit_metric/${id}`);
   };
 
   const handleDeleteMetric = () => {
@@ -20,11 +22,21 @@ const MetricsItem = ({ id, name, query_string, type, setIsEditing }) => {
         <p>Type: {type}</p>
       </div>
       <div>
-        <button onClick={handleEditMetric} className="border border-primary-violet text-primary-black rounded py-2 px-5 hover:text-primary-violet mr-2">Edit</button>
-        <button onClick={handleDeleteMetric} className="border border-primary-violet text-primary-black rounded py-2 px-5 hover:text-primary-violet">Delete</button>
+        <button
+          onClick={handleEditMetric}
+          className="border border-primary-violet text-primary-black rounded py-2 px-5 hover:text-primary-violet mr-2"
+        >
+          Edit
+        </button>
+        <button
+          onClick={handleDeleteMetric}
+          className="border border-primary-violet text-primary-black rounded py-2 px-5 hover:text-primary-violet"
+        >
+          Delete
+        </button>
       </div>
     </div>
   );
-}
+};
 
 export default MetricsItem;

--- a/client/src/components/MetricItem.jsx
+++ b/client/src/components/MetricItem.jsx
@@ -12,7 +12,9 @@ const MetricsItem = ({ id, name, query_string, type }) => {
   };
 
   const handleDeleteMetric = () => {
-    dispatch(deleteMetric(id));
+    if (window.confirm("Are you sure you want to delete this?")) {
+      dispatch(deleteMetric(id));
+    };
   };
 
   return (

--- a/client/src/components/MetricItem.jsx
+++ b/client/src/components/MetricItem.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { useDispatch } from "react-redux";
-import { editMetric, deleteMetric } from '../actions/metricActions';
+import { deleteMetric } from '../actions/metricActions';
 
-const MetricsItem = ({ id, name, query_string, type }) => {
+const MetricsItem = ({ id, name, query_string, type, setIsEditing }) => {
   const dispatch = useDispatch();
 
   const handleEditMetric = () => {
-    const updates = {};
-    dispatch(editMetric(id, updates));
+    setIsEditing(true);
   };
 
   const handleDeleteMetric = () => {

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -14,7 +14,7 @@ const MetricsPage = () => {
   useEffect(() => {
     dispatch(fetchMetrics());
   }, [dispatch]);
-  console.log(metrics);
+  // console.log(metrics);
 
   const handleOpenNewMetricForm = () => {
     setIsCreating(true);

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -8,7 +8,7 @@ const MetricsPage = () => {
   const dispatch = useDispatch();
   const metrics = useSelector(state => state.metrics);
   const dbName = useSelector(state => state.dbName);
-  const [ isCreating, setIsCreating ] = useState(false);
+  const [ isEditing, setIsEditing ] = useState(false);
   const isConnected = dbName ? true : false;
 
   useEffect(() => {
@@ -17,7 +17,7 @@ const MetricsPage = () => {
   // console.log(metrics);
 
   const handleOpenNewMetricForm = () => {
-    setIsCreating(true);
+    setIsEditing(true);
   };
 
   return (
@@ -27,9 +27,9 @@ const MetricsPage = () => {
           Note: Before you can create a metric, you must first set up the connection to your database in which your event data is stored.
         </div>
       }
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center my-3">
         <h2 className="text-3xl font-bold text-primary-violet">Metrics</h2>
-        {!isCreating ? (
+        {!isEditing &&
           <button
             className="btn bg-primary-turquoise"
             type="button"
@@ -37,21 +37,12 @@ const MetricsPage = () => {
           >
             Create New
           </button>
-        ) : (
-          <button
-            className="btn bg-slate"
-            type="button"
-            onClick={() => setIsCreating(false)}
-          >
-            Cancel
-          </button>
-        )
         }
       </div>
-      {isCreating && <NewMetricForm setIsCreating={setIsCreating} />}
+      {isEditing && <NewMetricForm setIsEditing={setIsEditing} />}
       <div>
         {metrics.length > 0 &&
-          metrics.map(metric => <MetricItem key={metric.id} {...metric} />)
+          metrics.map(metric => <MetricItem key={metric.id} {...metric} setIsEditing={setIsEditing} />)
         }
       </div>
     </div>

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -33,6 +33,7 @@ const MetricsPage = () => {
           className="btn bg-primary-turquoise"
           type="button"
           onClick={handleOpenNewMetricForm}
+          disabled={!isConnected}
         >
           Create New
         </button>

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -1,32 +1,59 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from "react-redux";
 import MetricItem from './MetricItem';
+import NewMetricForm from './NewMetricForm';
 import { fetchMetrics } from '../actions/metricActions';
 
 const MetricsPage = () => {
   const dispatch = useDispatch();
   const metrics = useSelector(state => state.metrics);
+  const dbName = useSelector(state => state.dbName);
+  const [ isCreating, setIsCreating ] = useState(false);
+  const isConnected = dbName ? true : false;
 
   useEffect(() => {
     dispatch(fetchMetrics());
   }, [dispatch]);
   console.log(metrics);
 
+  const handleOpenNewMetricForm = () => {
+    setIsCreating(true);
+  };
+
   return (
     <div className="w-full py-2.5 px-12">
+      {!isConnected &&
+        <div className="font-bold rounded bg-secondary-pink p-5 mt-10">
+          Note: Before you can create a metric, you must first set up the connection to your database in which your event data is stored.
+        </div>
+      }
       <div className="flex justify-between items-center">
         <h2 className="text-3xl font-bold text-primary-violet">Metrics</h2>
-        <button
-          className="btn bg-primary-turquoise"
-          type="button"
-          onClick={() => {}}
-        >
-          Create New
-        </button>
+        {!isCreating ? (
+          <button
+            className="btn bg-primary-turquoise"
+            type="button"
+            onClick={handleOpenNewMetricForm}
+          >
+            Create New
+          </button>
+        ) : (
+          <button
+            className="btn bg-slate"
+            type="button"
+            onClick={() => setIsCreating(false)}
+          >
+            Cancel
+          </button>
+        )
+        }
       </div>
-      {metrics.length > 0 &&
-        metrics.map(metric => <MetricItem key={metric.id} {...metric} />)
-      }
+      {isCreating && <NewMetricForm setIsCreating={setIsCreating} />}
+      <div>
+        {metrics.length > 0 &&
+          metrics.map(metric => <MetricItem key={metric.id} {...metric} />)
+        }
+      </div>
     </div>
   );
 };

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -12,6 +12,10 @@ const MetricsPage = () => {
   }, [dispatch]);
   console.log(metrics);
 
+  const handleOpenCreateForm = () => {
+
+  };
+
   return (
     <div className="w-full py-2.5 px-12">
       <div className="flex justify-between items-center">
@@ -19,7 +23,7 @@ const MetricsPage = () => {
         <button
           className="btn bg-primary-turquoise"
           type="button"
-          onClick={() => {}}
+          onClick={handleOpenCreateForm}
         >
           Create New
         </button>

--- a/client/src/components/MetricsPage.jsx
+++ b/client/src/components/MetricsPage.jsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import MetricItem from './MetricItem';
-import NewMetricForm from './NewMetricForm';
-import { fetchMetrics } from '../actions/metricActions';
+import MetricItem from "./MetricItem";
+import { fetchMetrics } from "../actions/metricActions";
 
 const MetricsPage = () => {
   const dispatch = useDispatch();
-  const metrics = useSelector(state => state.metrics);
-  const dbName = useSelector(state => state.dbName);
-  const [ isEditing, setIsEditing ] = useState(false);
+  const navigate = useNavigate();
+  const metrics = useSelector((state) => state.metrics);
+  const dbName = useSelector((state) => state.dbName);
   const isConnected = dbName ? true : false;
 
   useEffect(() => {
@@ -17,33 +17,30 @@ const MetricsPage = () => {
   // console.log(metrics);
 
   const handleOpenNewMetricForm = () => {
-    setIsEditing(true);
+    navigate("/edit_metric/new");
   };
 
   return (
     <div className="w-full py-2.5 px-12">
-      {!isConnected &&
+      {!isConnected && (
         <div className="font-bold rounded bg-secondary-pink p-5 mt-10">
-          Note: Before you can create a metric, you must first set up the connection to your database in which your event data is stored.
+          Note: Before you can create a metric, you must first set up the
+          connection to your database in which your event data is stored.
         </div>
-      }
+      )}
       <div className="flex justify-between items-center my-3">
         <h2 className="text-3xl font-bold text-primary-violet">Metrics</h2>
-        {!isEditing &&
-          <button
-            className="btn bg-primary-turquoise"
-            type="button"
-            onClick={handleOpenNewMetricForm}
-          >
-            Create New
-          </button>
-        }
+        <button
+          className="btn bg-primary-turquoise"
+          type="button"
+          onClick={handleOpenNewMetricForm}
+        >
+          Create New
+        </button>
       </div>
-      {isEditing && <NewMetricForm setIsEditing={setIsEditing} />}
       <div>
         {metrics.length > 0 &&
-          metrics.map(metric => <MetricItem key={metric.id} {...metric} setIsEditing={setIsEditing} />)
-        }
+          metrics.map((metric) => <MetricItem key={metric.id} {...metric} />)}
       </div>
     </div>
   );

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -58,7 +58,10 @@ const NewMetricForm = ({ setIsCreating }) => {
             </ul>
           </div>
           <div className="mt-2.5 flex items-center">
-            <label htmlFor="metric-query" className="inline-block w-1/3 text-right mr-5">Query to retrieve data (do not include semicolon): </label>
+            <label htmlFor="metric-query" className="inline-block w-1/3 text-center mr-5">
+              <p>Query to retrieve data:</p>
+              <p className="text-sm italic">Do not include semicolon. Query should result in <code>user_id</code>, <code>timestamp</code>, and <code>value</code> columns</p>
+            </label>
             <textarea id="metric-query" rows={6} cols={35} value={query} onChange={(e) => setQuery(e.target.value)} className="border border-slate rounded-lg p-2" />
           </div>
         </div>

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from "react-redux";
+import { createMetric } from '../actions/metricActions';
+
+const NewMetricForm = ({ setIsCreating }) => {
+  const dbName = useSelector(state => state.dbName);
+  const [ name, setName ] = useState('');
+  const [ type, setType ] = useState('');
+  const [ query, setQuery ] = useState('');
+  const dispatch = useDispatch();
+
+  const onTypeSelection = (e) => {
+    setType(e.target.value);
+  };
+
+  const handleSave = (e) => {
+    e.preventDefault();
+
+    if (!dbName) {
+      alert("Please set up your database connection first before creating a metric.");
+      return;
+    }
+    dispatch(createMetric({ name, type, query_string: query }));
+    setName('');
+    setType('');
+    setQuery('');
+    setIsCreating(false);
+  };
+
+  return (
+  <div>
+    <h2 className="text-xl font-bold border-b border-b-primary-black">New Metric</h2>
+    <form className="flex flex-col items-center">
+      <div>
+        <div className="mt-2.5">
+          <label htmlFor="metric-name" className="inline-block w-1/3 text-right mr-5">Name: </label>
+          <input id="metric-name" type="text" value={name} onChange={(e) => setName(e.target.value)} className="border border-slate rounded-lg p-2"/>
+        </div>
+        <div className="mt-2.5 flex items-center">
+          <label className="inline-block w-1/3 text-right mr-5">Type: </label>
+            <ul className="inline-block">
+              <li>
+                <input type="radio" id="binomial" name="metric-type" value="binomial" checked={type === "binomial"} onChange={onTypeSelection} />
+                <label htmlFor="binomial" className="inline-block pl-2">Binomial</label>
+              </li>
+              <li>
+                <input type="radio" id="count" name="metric-type" value="count" checked={type === "count"} onChange={onTypeSelection} />
+                <label htmlFor="count" className="inline-block pl-2">Count</label>
+              </li>
+              <li>
+                <input type="radio" id="duration" name="metric-type" value="duration" checked={type === "duration"} onChange={onTypeSelection} />
+                <label htmlFor="duration" className="inline-block pl-2">Duration</label>
+              </li>
+              <li>
+                <input type="radio" id="revenue" name="metric-type" value="revenue" checked={type === "revenue"} onChange={onTypeSelection} />
+                <label htmlFor="revenue" className="inline-block pl-2">Revenue</label>
+              </li>
+            </ul>
+          </div>
+          <div className="mt-2.5 flex items-center">
+            <label htmlFor="metric-query" className="inline-block w-1/3 text-right mr-5">Query to retrieve data (do not include semicolon): </label>
+            <textarea id="metric-query" rows={6} cols={35} value={query} onChange={(e) => setQuery(e.target.value)} className="border border-slate rounded-lg p-2" />
+          </div>
+        </div>
+      <button onClick={handleSave} className="btn bg-primary-turquoise m-auto">Save Changes</button>
+    </form>
+  </div>
+  );
+};
+
+export default NewMetricForm;

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -47,12 +47,14 @@ const NewMetricForm = () => {
     navigate('/metrics');
   };
 
-  const handleSave = (e) => {
+  const handleSave = async (e) => {
     e.preventDefault();
     if (validateInputs()) {
-      dispatch(createMetric({ name, type, query_string: query }));
-      resetForm();
-      navigate('/metrics');
+      const success = await dispatch(createMetric({ name, type, query_string: query }));
+      if (success) {
+        resetForm();
+        navigate('/metrics');
+      }
     }
   };
 

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -36,11 +36,11 @@ const NewMetricForm = () => {
       alert("Name must be unique");
       return false;
     }
-    setQuery(query.trim());
     if (name.length === 0 || type === '' || query === '') {
       alert("Please check your inputs and try again.");
       return false;
     }
+    console.log(query);
     if (query[query.length - 1] === ';') {
       alert("Semicolons not allowed, please remove and try again.");
       return false;
@@ -55,6 +55,7 @@ const NewMetricForm = () => {
   const handleSave = async (e) => {
     e.preventDefault();
     let success;
+    setQuery(query.trim());
     if (validateInputs()) {
       const fields = { name, type, query_string: query };
       if (isNew) {

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useSelector, useDispatch } from "react-redux";
 import { createMetric } from '../actions/metricActions';
 
-const NewMetricForm = ({ setIsCreating }) => {
+const NewMetricForm = ({ setIsEditing }) => {
   const dbName = useSelector(state => state.dbName);
   const [ name, setName ] = useState('');
   const [ type, setType ] = useState('');
@@ -24,7 +24,7 @@ const NewMetricForm = ({ setIsCreating }) => {
     setName('');
     setType('');
     setQuery('');
-    setIsCreating(false);
+    setIsEditing(false);
   };
 
   return (
@@ -65,7 +65,10 @@ const NewMetricForm = ({ setIsCreating }) => {
             <textarea id="metric-query" rows={6} cols={35} value={query} onChange={(e) => setQuery(e.target.value)} className="border border-slate rounded-lg p-2" />
           </div>
         </div>
-      <button onClick={handleSave} className="btn bg-primary-turquoise m-auto">Save Changes</button>
+      <div>
+        <button onClick={handleSave} className="btn bg-primary-turquoise">Save Changes</button>
+        <button onClick={() => setIsEditing(false)} className="btn bg-slate">Cancel</button>
+      </div>
     </form>
   </div>
   );

--- a/client/src/lib/ApiClient.js
+++ b/client/src/lib/ApiClient.js
@@ -76,6 +76,13 @@ const apiClient = {
       .then(callback)
       .catch(logError);
   },
+  createMetric: function(metricObj, callback) {
+    return axios
+      .post('/api/metrics', metricObj)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError);
+  },
   editMetric: function(id, updatedFields, callback) {
     return axios
       .put(`/api/metrics/${id}`, updatedFields)

--- a/client/src/reducers/metrics.js
+++ b/client/src/reducers/metrics.js
@@ -3,6 +3,9 @@ export default function metrics(state = [], action) {
     case "FETCH_METRICS_SUCCESS": {
       return action.metrics;
     }
+    case "CREATE_METRIC_SUCCESS": {
+      return [ ...state, action.metric ];
+    }
     case "EDIT_METRIC_SUCCESS": {
       return state.map(metric => {
         if (metric.id === action.metric.id) {

--- a/server/controllers/metricsController.js
+++ b/server/controllers/metricsController.js
@@ -26,7 +26,7 @@ const validateQuery = async (req, res, next) => {
 
 const getMetrics = async (req, res, next) => {
   try {
-    const metrics = await metricsTable.getAllRows();
+    const metrics = await metricsTable.getAllRowsNotDeleted();
     res.status(200).send(metrics);
   } catch (err) {
     console.log(err);
@@ -79,12 +79,11 @@ const editMetric = async (req, res, next) => {
 const deleteMetric = async (req, res, next) => {
   const id = req.params.id;
   try {
-    const result = await metricsTable.deleteRow(id);
-    if (result.rows.length === 0) {
+    const result = await metricsTable.editRow({ is_deleted: true }, { id: Number(id) });
+    if (!result) {
       throw new Error(`Metric with id ${id} doesn't exist`);
     }
-    const deletedMetricName = result.rows[0].name;
-    res.status(200).send(`Metric '${deletedMetricName}' with id ${id} successfully deleted`);
+    res.status(200).send(result);
   } catch (err) {
     res.status(500).send(err.message);
   }

--- a/server/controllers/metricsController.js
+++ b/server/controllers/metricsController.js
@@ -8,7 +8,7 @@ metricsTable.init();
 
 const validateQuery = async (req, res, next) => {
   try {
-    const queryResult = await eventDbQuery(`${req.body.query_string} WHERE FALSE;`);
+    const queryResult = await eventDbQuery(`SELECT * FROM (${req.body.query_string}) AS provided_query WHERE FALSE;`);
     const tableCols = queryResult.fields.map(field => field.name);
     const required = ['user_id', 'timestamp', 'value'];
     for (let i = 0; i < required.length; i++) {

--- a/server/db/PGTable.js
+++ b/server/db/PGTable.js
@@ -89,6 +89,12 @@ module.exports = class PGTable {
     return result.rows;
   }
 
+  async getAllRowsNotDeleted() {
+    const statement = `SELECT * FROM ${this.tableName} WHERE is_deleted = FALSE`;
+    const result = await dbQuery(statement);
+    return result.rows;
+  }
+
   async getRow(id) {
     const statement = `SELECT * FROM ${this.tableName} WHERE id = ${id}`;
     const result = await dbQuery(statement);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -59,9 +59,9 @@ router.get("/metrics", metricsController.getMetrics);
 
 router.get("/metrics/:id", metricsController.getMetric);
 
-router.post("/metrics", metricsController.createMetric);
+router.post("/metrics", metricsController.validateQuery, metricsController.createMetric);
 
-router.put("/metrics/:id", metricsController.editMetric);
+router.put("/metrics/:id", metricsController.validateQuery, metricsController.editMetric);
 
 router.delete("/metrics/:id", metricsController.deleteMetric);
 


### PR DESCRIPTION
Implemented all the frontend functionality for users to be able to manage their metrics in the Metrics page. I used the same component for creating and editing a metric, and it has its own path `/edit_metric/:id`. If it's an edit, the `id` will be the id of the metric being edited, and if it's a create new metric, then the `id` will just be 'new'. The component then uses this param to determine its behavior (editing vs. creating).

Firstly, the user is not able to create metrics until their database connection is set up. So if they are not connected, they will see a big banner at the top of the page telling them to go set that up. The "Create New" form will also not let them submit. Feel free to try disconnecting to see the different experience.

Most of the challenge here was with validating the inputs, because when a user edits or creates a metric, the query string has to be validated against their database. It's hard to validate a correct SQL query in the frontend alone so we have to wait for the backend to run it and see what happens. 

So when the user clicks submit, our backend runs their query + `WHERE FALSE` to get the column names, and then if there are any errors, the error gets propagated back to the frontend so that the user can see the error message as a window alert. The response then includes an object containing an `ok` property which will be either `true` for successful or `false` for unsuccessful, the error message if it was unsuccessful, and the data itself if it was successful. I had to change the controllers and the Redux action creators a bit to return the right data from all the functions.

Try it out and see the different errors you can get!

Below are some examples:
Non-unique name
![duplicate name](https://user-images.githubusercontent.com/75290988/158510430-a133a084-73bd-4da5-a036-7d3432c52680.jpg)
SQL Syntax error
![syntax error](https://user-images.githubusercontent.com/75290988/158510437-09095ad1-ea27-4c7f-99eb-a6f7cd9024a2.jpg)

