### PR TITLE
Fixed updating of expts after stop expt. Cleaned up webhook error handling.

### DIFF
--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -120,7 +120,7 @@ const FlagDetailsPage = () => {
         <EditFlagForm setIsEditing={setIsEditing} />
       )}
       {exptData &&
-        exptData.sort((a, b) => Number(b.id) - Number(a.id)).map((expt) => {
+        exptData.map((expt) => {
           return <ExperimentInfo key={expt.id} data={expt} />;
         })}
     </div>

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -47,7 +47,6 @@ const FlagDetailsPage = () => {
     const runningExptId = exptData.find(expt => expt.date_ended === null).id;
     dispatch(editFlag(flagId, { is_experiment: false}));
     dispatch(editExperiment(runningExptId, { date_ended: true}));
-    setExptsFetched(false);
   };
 
   const handleToggle = (id) => {
@@ -121,7 +120,7 @@ const FlagDetailsPage = () => {
         <EditFlagForm setIsEditing={setIsEditing} />
       )}
       {exptData &&
-        exptData.map((expt) => {
+        exptData.sort((a, b) => Number(b.id) - Number(a.id)).map((expt) => {
           return <ExperimentInfo key={expt.id} data={expt} />;
         })}
     </div>

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -1,10 +1,10 @@
 export default function experiments(state = [], action) {
   switch (action.type) {
     case "FETCH_EXPERIMENTS_SUCCESS": {
-      return action.experiments;
+      return [...action.experiments];
     }
     case "CREATE_EXPERIMENT_SUCCESS": {
-      return [...state, action.newExpt];
+      return [action.newExpt, ...state];
     }
     case "EDIT_EXPERIMENT_SUCCESS": {
       let newState = [...state];

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -5,5 +5,5 @@ exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.GET_EXPERIMENTS_QUERY = `SELECT *  FROM experiments
                                  WHERE flag_id = $1
-                                 ORDER BY date_started DESC;`;
+                                 ORDER BY id DESC;`;
 exports.METRIC_TYPES = ['binomial', 'count', 'duration', 'revenue'];

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -62,6 +62,7 @@ const editExperiment = async (req, res, next) => {
       updatedFields.date_ended = getNowString();
     }
     const updatedExpt = await experimentsTable.editRow(updatedFields, { id: id });
+    req.updatedExpt = updatedExpt;
     // If regular edit, not stopping experiment, just send back updated expt
     if (!updatedFields.date_ended) {
       res.status(200).send(updatedExpt);
@@ -85,7 +86,8 @@ const updateExperimentData = async (req, res, next) => {
 const getAnalysis = async (req, res, next) => {
   const id = req.params.id;
   // Statistics and fill in the data in the experiments table
-  res.status(200).send("Analysis")
+  res.status(200).send(req.updatedExpt); // use for now until analysis is created
+  // res.status(200).send("Analysis")
 };
 
 exports.getExperimentsForFlag = getExperimentsForFlag;

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -5,11 +5,6 @@ const { FLAG_TABLE_NAME } = require("../constants/db");
 const { getNowString } = require("../utils");
 const { sendWebhook } = require("../lib/sendWebhook.js");
 const { getFlagsForWebhook } = require("../db/flags.js");
-const {
-  createExperiment,
-  stopExperiment,
-} = require("./experimentController.js");
-// const { status } = require("./streamController");
 
 const flagTable = new PGTable(FLAG_TABLE_NAME);
 flagTable.init();
@@ -34,15 +29,6 @@ const createNewFlagObj = ({
     is_deleted: false,
   };
 };
-
-// const createUpdateFlagObj = (fieldsToUpdate) => {
-//   const now = getNowString();
-//
-//   if (fieldsToUpdate.status !== undefined) fieldsToUpdate["last_toggle"] = now;
-//   fieldsToUpdate["date_edited"] = now;
-//
-//   return fieldsToUpdate;
-// }
 
 const getAllFlags = async (req, res, next) => {
   try {
@@ -147,7 +133,6 @@ const sendFlagsWebhook = async (req, res, next) => {
     console.log("webhook sent");
     res.status(200);
   } catch (err) {
-    console.log(err);
     console.log("Could not send webhook");
   }
 };

--- a/server/lib/sendWebhook.js
+++ b/server/lib/sendWebhook.js
@@ -5,8 +5,7 @@ async function sendWebhook(data) {
   try {
     await axios.post(process.env.FLAG_PROVIDER_URL, data);
   } catch (err) {
-    console.log(err);
-    console.log("Error sending webhook");
+    throw new Error("Error sending webhook");
   }
 }
 


### PR DESCRIPTION
The root of the issue was that when I clicked "Stop Experiment" and sent a PUT request to the backend, I received back "Analysis" instead of the updated experiment data. This string was getting added to my experiments store instead of the updated experiment data.

To fix this, I altered the `getAnalysis` function on the `experimentsController` to just send the updated experiment data until we build out the analysis functions.

Other fixes:
- The experiments are now sorted by ID in descending order, since the ID's are created sequentially, this'll automatically sort by most recent -> oldest
- I removed some console.logging of errors in the `sendWebhook` function in _sendWebhook.js_ and `flagsController.sendFlagsWebhook`.
- `sendWebhook` now throws an error when the webhook can't be sent, and that error is caught by `flagsController.sendWebhook` and the proper error message is logged. (before it was logging "webhook sent" even though the webhook wasn't being sent)