### PR TITLE
Users can view and edit what metrics are on each experiment

### DIFF
--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -12,7 +12,9 @@ export function fetchExperimentsSuccess(experiments) {
 
 export function createExperiment(exptObj) {
   return function(dispatch) {
-    apiClient.createExperiment(exptObj, data => dispatch(createExperimentSuccess(data)));
+    apiClient.createExperiment(exptObj, data => {
+      dispatch(createExperimentSuccess(data))
+    });
   }
 }
 

--- a/client/src/components/EditExperiment.jsx
+++ b/client/src/components/EditExperiment.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react";
 import { editExperiment } from "../actions/exptActions";
 import { useDispatch } from "react-redux";
+import MetricCheckbox from "./MetricCheckbox";
 
 
-const EditExperiment = ({ id, name, description, duration, date_started, date_ended, setIsEditing }) => {
+const EditExperiment = ({ id, name, description, duration, date_started, date_ended, metrics, allMetrics, setIsEditing }) => {
   const dispatch = useDispatch();
+  const origMetricIds = metrics.map((m) => m.metric_id);
   const [newName, setNewName] = useState(name || "");
   const [newDescription, setNewDescription] = useState(description || "");
   const [newDuration, setNewDuration] = useState(duration);
+  const [newMetricIds, setNewMetricIds] = useState(origMetricIds);
   const inputCSS = "border border-primary-oxfordblue rounded-lg px-2";
-
   const startDate = new Date(date_started).toLocaleDateString("en-US");
 
   const getChangedData = () => {
@@ -17,6 +19,10 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
     if (newName !== name) edits.name = newName;
     if (Number(newDuration) !== Number(duration)) edits.duration = newDuration;
     if (newDescription !== description) edits.description = newDescription;
+    if (newMetricIds.join(", ") !== origMetricIds.join(", ")) {
+      edits.metric_ids = newMetricIds;
+      edits.old_metric_ids = origMetricIds;
+    }
     return edits;
   }
 
@@ -35,7 +41,19 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
       errMessage += "- The length of the name is too long (max 50 char)\n"
     }
 
+    if (newMetricIds.length === 0) {
+      errMessage += "- You must have at least one metric measured per experiment"
+    }
+
     return errMessage
+  }
+
+  const toggleMetric = (id) => {
+    if (newMetricIds.includes(id)) {
+      setNewMetricIds(newMetricIds.filter(existingId => existingId !== id))
+    } else {
+      setNewMetricIds([...newMetricIds, id]);
+    }
   }
 
   const submitEdits = (e) => {
@@ -65,6 +83,14 @@ const EditExperiment = ({ id, name, description, duration, date_started, date_en
       <p>Name: <input className={inputCSS} value={newName} onChange={(e) => setNewName(e.target.value)}/></p>
       <p>Duration: <input className={inputCSS} type="number" value={newDuration} onChange={(e) => setNewDuration(e.target.value)}/> days</p>
       <p>Description: <input className={inputCSS} value={newDescription} onChange={(e) => setNewDescription(e.target.value)}/></p>
+      <div className="my-5">
+          <h3 className="font-bold text-base">Select the metrics you want to measure:</h3>
+          <div className="flex mt-2.5 mx-3 justify-start">
+          {allMetrics.map(({ id, name }) => (
+            <MetricCheckbox key={id} id={id} name={name} selected={newMetricIds.includes(id)} handleClick={() => toggleMetric(id)} />
+          ))}
+          </div>
+      </div>
       <p className="text-primary-violet">Note: if you'd like to change the rollout of this experiment, edit the rollout of this flag by hitting the "Edit" button near the top of the page</p>
     </>
   )

--- a/client/src/components/ExperimentInfo.jsx
+++ b/client/src/components/ExperimentInfo.jsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
 import EditExperiment from "./EditExperiment";
 
-const ExperimentInfo = ({ data }) => {
-  const { id, name, description, duration, date_started, date_ended } = data;
+const ExperimentInfo = ({ data, allMetrics }) => {
+  const { id, name, description, duration, date_started, date_ended, metrics } = data;
   const [isEditing, setIsEditing] = useState(false);
   const startDate = new Date(date_started).toLocaleDateString("en-US");
   const endDate = date_ended ? new Date(date_ended).toLocaleDateString("en-US") : "Present";
+  const metricsNames = metrics.map((metric) => {
+    return allMetrics.find(m => m.id === metric.metric_id).name
+  }).join(", ");
+
 
   return (
     <div className="border border-dashed border-primary-oxfordblue rounded p-5 my-4">
@@ -19,11 +23,12 @@ const ExperimentInfo = ({ data }) => {
           {name && <p>Name: <span className="font-bold">{name}</span></p>}
           <p>Duration: <span className="font-bold">{duration + " days"}</span></p>
           {description && <p>Description: <span className="font-bold">{description}</span></p>}
+          <p>Metrics measured: <span className="font-bold">{metricsNames}</span></p>
           <p>Details about experiment analysis, charts and stats go here</p>
         </>
     ) : (
       <>
-        <EditExperiment setIsEditing={setIsEditing} {...data}/>
+        <EditExperiment setIsEditing={setIsEditing} allMetrics={allMetrics} {...data}/>
       </>
     )
       }

--- a/client/src/components/FlagDetailsPage.jsx
+++ b/client/src/components/FlagDetailsPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchFlags, toggleFlag, editFlag } from "../actions/flagActions";
 import { fetchExperiments, editExperiment } from "../actions/exptActions";
+import { fetchMetrics } from "../actions/metricActions";
 import { useParams, useNavigate } from "react-router-dom";
 import EditFlagForm from "./EditFlagForm";
 import ExperimentInfo from "./ExperimentInfo";
@@ -14,8 +15,10 @@ const FlagDetailsPage = () => {
     state.flags.find((flag) => flag.id === +flagId)
   );
   const exptData = useSelector((state) => state.experiments);
+  const metricData = useSelector((state) => state.metrics);
   const [flagFetched, setFlagFetched] = useState(false);
   const [exptsFetched, setExptsFetched] = useState(false);
+  const [metricsFetched, setMetricsFetched] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
@@ -24,6 +27,13 @@ const FlagDetailsPage = () => {
       setFlagFetched(true);
     }
   }, [dispatch, flagId, flagFetched]);
+
+  useEffect(() => {
+    if (!metricsFetched) {
+      dispatch(fetchMetrics());
+      setMetricsFetched(true);
+    }
+  }, [dispatch, metricsFetched]);
 
   useEffect(() => {
     if (!exptsFetched) {
@@ -55,7 +65,7 @@ const FlagDetailsPage = () => {
     };
   };
 
-  if (!flagData || !exptData) return null;
+  if (!flagData || !exptData || !metricData) return null;
   return (
     <div className="py-5 px-8 w-full">
       <div className="flex justify-between items-center border-b border-b-primary-oxfordblue mb-5">
@@ -121,7 +131,7 @@ const FlagDetailsPage = () => {
       )}
       {exptData &&
         exptData.map((expt) => {
-          return <ExperimentInfo key={expt.id} data={expt} />;
+          return <ExperimentInfo key={expt.id} allMetrics={metricData} data={expt} />;
         })}
     </div>
   );

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -1,7 +1,6 @@
 export default function experiments(state = [], action) {
   switch (action.type) {
     case "FETCH_EXPERIMENTS_SUCCESS": {
-      console.log(action.experiments);
       return [...action.experiments];
     }
     case "CREATE_EXPERIMENT_SUCCESS": {

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -11,9 +11,10 @@ export default function experiments(state = [], action) {
       const indexOfEdited = newState.findIndex((expt) => (
         expt.id === action.editedExpt.id
       ));
-      // save exposures to variable 
+      const exposures = newState[indexOfEdited].exposures;
       newState[indexOfEdited] = action.editedExpt;
-      // put exposures on new var
+      newState[indexOfEdited].exposures = exposures;
+
       return newState;
     }
     default: {

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -1,6 +1,7 @@
 export default function experiments(state = [], action) {
   switch (action.type) {
     case "FETCH_EXPERIMENTS_SUCCESS": {
+      console.log(action.experiments);
       return [...action.experiments];
     }
     case "CREATE_EXPERIMENT_SUCCESS": {

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -11,7 +11,9 @@ export default function experiments(state = [], action) {
       const indexOfEdited = newState.findIndex((expt) => (
         expt.id === action.editedExpt.id
       ));
+      // save exposures to variable 
       newState[indexOfEdited] = action.editedExpt;
+      // put exposures on new var
       return newState;
     }
     default: {

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -14,4 +14,4 @@ exports.GET_EXPOSURES_ON_EXPT = `SELECT variant, num_users, date
                                  WHERE experiment_id = $1
                                  ORDER BY date ASC;`
 exports.METRIC_TYPES = ['binomial', 'count', 'duration', 'revenue'];
-exports.REQUIRED_EVENT_DB_COLS = ['user_id', 'timestamp', 'treatment'];
+exports.REQUIRED_EVENT_DB_COLS = ['experiment_id', 'user_id', 'timestamp', 'treatment'];

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -4,8 +4,8 @@ exports.EXPERIMENT_METRICS_TABLE_NAME = "experiment_metrics";
 exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.CONNECTION_TABLE_NAME = "connection";
-exports.GET_EXPERIMENTS_QUERY = `SELECT * FROM experiments AS e
-                                 JOIN experiment_metrics AS em
+exports.GET_EXPERIMENTS_QUERY = `SELECT e.*, em.metric_id FROM experiments e
+                                 JOIN experiment_metrics em
                                  ON e.id=em.experiment_id
                                  WHERE flag_id = $1
                                  ORDER BY id DESC;`;

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -4,10 +4,14 @@ exports.EXPERIMENT_METRICS_TABLE_NAME = "experiment_metrics";
 exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.CONNECTION_TABLE_NAME = "connection";
-exports.GET_EXPERIMENTS_QUERY = `SELECT e.*, em.metric_id FROM experiments e
+exports.GET_EXPT_METRICS_QUERY = `SELECT * FROM experiments e
                                  JOIN experiment_metrics em
                                  ON e.id=em.experiment_id
                                  WHERE flag_id = $1
                                  ORDER BY id DESC;`;
+exports.GET_EXPOSURES_ON_EXPT = `SELECT variant, num_users, date
+                                 FROM exposures
+                                 WHERE experiment_id = $1
+                                 ORDER BY date ASC;`
 exports.METRIC_TYPES = ['binomial', 'count', 'duration', 'revenue'];
 exports.REQUIRED_EVENT_DB_COLS = ['user_id', 'timestamp', 'treatment'];

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -4,7 +4,9 @@ exports.EXPERIMENT_METRICS_TABLE_NAME = "experiment_metrics";
 exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.CONNECTION_TABLE_NAME = "connection";
-exports.GET_EXPERIMENTS_QUERY = `SELECT *  FROM experiments
+exports.GET_EXPERIMENTS_QUERY = `SELECT * FROM experiments AS e
+                                 JOIN experiment_metrics AS em
+                                 ON e.id=em.experiment_id
                                  WHERE flag_id = $1
                                  ORDER BY id DESC;`;
 exports.METRIC_TYPES = ['binomial', 'count', 'duration', 'revenue'];

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -1,5 +1,5 @@
 const PGTable = require("../db/PGTable");
-const { EXPERIMENTS_TABLE_NAME, EXPERIMENT_METRICS_TABLE_NAME, EXPOSURES_TABLE_NAME, GET_EXPERIMENTS_QUERY } = require("../constants/db");
+const { EXPERIMENTS_TABLE_NAME, EXPERIMENT_METRICS_TABLE_NAME, EXPOSURES_TABLE_NAME, GET_EXPT_METRICS_QUERY, GET_EXPOSURES_ON_EXPT } = require("../constants/db");
 const { getNowString } = require("../utils");
 
 const experimentsTable = new PGTable(EXPERIMENTS_TABLE_NAME);
@@ -22,28 +22,88 @@ const getExperiment = async (req, res, next) => {
 
 // takes arr of joined expt and metric_id data with duplicate experiments
 // returns arr with no duplicate experiments and metric_ids property is an arr
-const transformMetricExptData = (experiments) => {
+// [
+//   {
+//     id: 1,
+//     name: experiment1,
+//     ...,
+//     metrics: [{ metric_id: 1, mean_test: ..., mean_control: ..., ...}, ...],
+//     exposures_test: { "2022-03-08": 5, "2022-03-09": 10, ... },
+//     exposures_control: { "2022-03-08": 5, "2022-03-09": 10, ... }
+//   }
+// ]
+
+const separateMetricExperimentData = (metricExpt) => {
+  const {
+    metric_id,
+    mean_test,
+    mean_control,
+    standard_dev_test,
+    standard_dev_control,
+    p_value,
+    ...expt
+  } = metricExpt;
+
+  const metricObj = {
+    metric_id,
+    mean_test,
+    mean_control,
+    standard_dev_test,
+    standard_dev_control,
+    p_value
+  };
+
+  return [expt, metricObj];
+}
+
+const transformMetricExptData = (exptMetrics) => {
   let idMap = {};
-  experiments.forEach((expt) => {
+  exptMetrics.forEach((exptMetric) => {
+    const [expt, metricObj] = separateMetricExperimentData(exptMetric);
     if (idMap[expt.id]) {
-      idMap[expt.id].push(expt.metric_id)
+      idMap[expt.id].push(metricObj)
     } else {
-      idMap[expt.id] = [expt.metric_id];
+      idMap[expt.id] = [metricObj];
     }
   });
 
-  return = Object.keys(idMap).map((exptId) => {
-    const { metric_id, ...expt } = experiments.find((e) => e.id === Number(exptId));
-    expt.metric_ids = idMap[exptId];
+  const experiments =  Object.keys(idMap).map((exptId) => {
+    const exptMetric = exptMetrics.find((e) => e.id === Number(exptId))
+    const [expt, metricObj] = separateMetricExperimentData(exptMetric);
+    expt.metrics = idMap[exptId];
     return expt;
   })
+  experiments.sort((a, b) => b.id - a.id);
+  return experiments;
+}
+
+const createExposureObj = (exposuresArr, variant) => {
+  const obj = {};
+  exposuresArr = exposuresArr.filter((expo) => expo.variant === variant);
+  exposuresArr.forEach((expo) => {
+    const date = String(expo.date).split("T")[0]
+    obj[date] = expo.num_users
+  })
+  return obj;
 }
 
 const getExperimentsForFlag = async (req, res, next) => {
   const flagId = req.params.id;
   try {
-    let { rows: experiments } = await experimentsTable.query(GET_EXPERIMENTS_QUERY, [flagId]);
-    experiments = transformMetricExptData(experiments);
+    let { rows: exptMetrics } = await experimentsTable.query(GET_EXPT_METRICS_QUERY, [flagId]);
+    const experiments = transformMetricExptData(exptMetrics);
+    // attaches exposures to running experiment
+    const runningExpt = experiments.find((expt) => expt.date_ended === null);
+    if (runningExpt) {
+      let { rows: exposures } = await exposuresTable.query(GET_EXPOSURES_ON_EXPT, [1]);
+      if (exposures.length > 0) {
+        const exposures_test = createExposureObj(exposures, "test")
+        const exposures_control = createExposureObj(exposures, "control")
+        runningExpt.exposures_test = exposures_test;
+        runningExpt.exposures_control = exposures_control;
+      }
+    }
+
     res.status(200).send(experiments);
   } catch (err) {
     console.log(err);

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -21,9 +21,10 @@ const getExperiment = async (req, res, next) => {
 };
 
 const getExperimentsForFlag = async (req, res, next) => {
-  const id = req.params.id;
+  const flagId = req.params.id;
   try {
-    const experiments = await experimentsTable.query(GET_EXPERIMENTS_QUERY, [id]);
+    const experiments = await experimentsTable.query(GET_EXPERIMENTS_QUERY, [flagId]);
+    console.log(experiments);
     res.status(200).send(experiments.rows);
   } catch (err) {
     console.log(err);

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -123,10 +123,13 @@ const createExperiment = async (req, res, next) => {
     };
     const newExpt = await experimentsTable.insertRow(exptObj);
     // Add each metric_id to experiment_metrics with the experiment_id
-    req.body.metric_ids.forEach(async (metricId) => {
-        await experimentMetricsTable.insertRow({ experiment_id: newExpt.id, metric_id: metricId });
-    });
-    newExpt.metric_ids = req.body.metric_ids;
+    for (let i = 0; i < req.body.metric_ids.length; i++) {
+      const metricId = req.body.metric_ids[i];
+      await experimentMetricsTable.insertRow({ experiment_id: newExpt.id, metric_id: metricId });
+    }
+
+    const metrics = await experimentMetricsTable.getRowsWhere({ experiment_id: newExpt.id });
+    newExpt.metrics = metrics;
     res.status(200).send(newExpt);
   } catch (err) {
     console.log(err);

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -111,7 +111,7 @@ const editFlag = async (req, res, next) => {
 const deleteFlag = async (req, res, next) => {
   const id = req.params.id;
   try {
-    const result = await flagTable.deleteRow(id);
+    const result = await flagTable.deleteRow({ id });
     if (result.rows.length === 0)
       throw new Error(`Flag with the id of ${id} doesn't exist`);
 

--- a/server/db/db-query.js
+++ b/server/db/db-query.js
@@ -10,11 +10,11 @@ const logQuery = (statement, parameters) => {
 module.exports = {
   async dbQuery(statement, ...parameters) {
     const client = new Client({
-      user: process.env.DB_USER,
-      host: "localhost",
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB,
-      port: 5432,
+      user: process.env.POSTGRES_USER,
+      host: process.env.POSTGRES_HOST,
+      password: process.env.POSTGRES_PASSWORD,
+      database: process.env.POSTGRES_DB,
+      port: process.env.POSTGRES_PORT,
     });
 
     await client.connect();


### PR DESCRIPTION
Users can view the names of metrics that are on an experiment. 
![image](https://user-images.githubusercontent.com/59182147/158909002-40071fe7-b303-4ae6-a47d-07b6566aaee9.png)
They can also edit which metrics are on the experiment.
![image](https://user-images.githubusercontent.com/59182147/158909030-ea04f025-e1c9-40d0-a2ec-55a497dc9616.png)

In order to complete this I had to do a major overhaul of the `createExperiment`, `getExperimentsForFlag`, and `editExperiment` functions on the experiment controller.
- I had to query and attach data from the `experiments_metrics` table
  - This was done with a JOIN and some transformations in `getExperimentsForFlag`
  - This was done with a separate query for a specific experiment in `create...` and `editExperiment`
- In `editExperiment` I handled the difference in metric IDs by passing in an `old_metric_ids` array from the frontend if the metric_ids were being changed, then I compared the new and old metric IDs and inserted/deleted rows from `experiment_metrics` table accordingly. Then I queried that table for the newest values in that table and attached them to the `updatedExpt` object that was returned.
- The `getExperimentsForFlag` function now grabs the exposures on the running experiment, if there is one. I tested this in the beginning, but it might need to be tested again.

I added/changed some functionality to the PGTable class to make the above easier.
- Changed the `deleleRow` method to accept a `where` object, for easy deletion using any criteria
- Created a `getRowsWhere` method that runs a SELECT query with a WHERE clause

In the frontend:
- I had to edit the `experiments` reducer to keep the exposures on an edited experiment object.
- I added `metricData` to the `FlagDetailsPage` component, which uses useSelector and grabs the metric data in the event the state is empty, much like it does with `flagData` and `exptData`
- I changed the `ExperimentInfo` component to accept an `allMetrics` prop which passed in from the `FlagDetailsPage`. This prop is used when editing the experiment to show the user all the available metrics.
- As of right now I am just showing the names of the metrics per each experiment, not any statistics about each one (sample size, std deviation, etc)
- Changed the `EditExperiments` component so you can edit what metrics you want on the experiment. This is validated to make sure there's at least one metric on the experiment. I used the `MetricCheckbox` component to implement this.

# Future work
- Figure out a way to properly display the statistics for each metric. If we don't want to display it automatically (maybe it'll crowd the page), then maybe we can click a dropdown that'll open up a table for viewing. The data for this is already grabbed on the front-end and in the store, it just needs to be displayed.
- When we get the statistical stuff done, a call must be made to re-analyze data when a metric is added to an existing experiment.