### PR TITLE
Fix nav links so they don't refresh the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 
 #Postgres
 *.sql
+seedDatabase.js

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -24,10 +24,10 @@ function App() {
 
   return (
     <>
-      <Header setDbModalOpen={setDbModalOpen} />
-      <main className="flex w-full h-full">
-        <SideNav />
-        <BrowserRouter>
+      <BrowserRouter>
+        <Header setDbModalOpen={setDbModalOpen} />
+        <main className="flex w-full h-full">
+          <SideNav />
           <Routes>
             <Route exact path="/" element={<FlagDashboard />} />
             <Route path="/flags/:flagId" element={<FlagDetailsPage />} />
@@ -35,9 +35,9 @@ function App() {
             <Route path="/metrics" element={<MetricsPage />} />
             <Route path="/edit_metric/:id" element={<NewMetricForm />} />
           </Routes>
-        </BrowserRouter>
-      </main>
-      <DBModal modalOpen={dbModalOpen} setModalOpen={setDbModalOpen} />
+        </main>
+        <DBModal modalOpen={dbModalOpen} setModalOpen={setDbModalOpen} />
+      </BrowserRouter>
     </>
   );
 }

--- a/client/src/components/SideNav.jsx
+++ b/client/src/components/SideNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const navLinks =[
   { id: 1, title: 'Flags Dashboard', path: "/" },
@@ -7,15 +8,14 @@ const navLinks =[
 ]
 
 const SideNav = () => {
+  const navigate = useNavigate();
   return (
     <div className="bg-primary-black text-primary-offwhite min-h-screen w-80 min-w-min">
       <img src="/assets/PNGs/Waypost_logo_on_dark.png" alt="Waypost" />
       <ul className="font-bold p-0">
         {navLinks.map(item => {
           return (
-            <a key={`a-${item.id}`} href={item.path}>
-              <li key={`li-${item.id}`} className="p-5 hover:bg-primary-violet hover:text-primary-offwhite">{item.title}</li>
-            </a>
+            <li key={`li-${item.id}`} onClick={() => navigate(item.path)} className="p-5 hover:cursor-pointer hover:bg-primary-violet hover:text-primary-offwhite">{item.title}</li>
             )
         })}
       </ul>


### PR DESCRIPTION
Before, clicking on the sidebar would cause a full page refresh. I figured out this was because it was using an anchor tag with a path, so I removed the anchor tags and added an onClick handler using the `navigate()` function instead.