### PR TITLE
Updated query string input instructions

### DIFF
--- a/client/src/components/DBModal.jsx
+++ b/client/src/components/DBModal.jsx
@@ -98,7 +98,7 @@ const DBModal = ({ modalOpen, setModalOpen }) => {
           <div className="mt-2.5 flex items-center">
             <label htmlFor="query" className="inline-block w-1/3 text-center mr-5">
               <p>Query to retrieve experiment data:</p>
-              <p className="text-sm italic">Do not include semicolon. Query should result in <code>user_id</code>, <code>timestamp</code>, and <code>treatment</code> columns</p>
+              <p className="text-sm italic">Do not include semicolon. Query should result in <code>experiment_id</code>, <code>user_id</code>, <code>timestamp</code>, and <code>treatment</code> columns</p>
             </label>
             <textarea id="query" rows={4} cols={35} value={query} onChange={(e) => setQuery(e.target.value)} className="border border-slate rounded-lg p-2" />
           </div>

--- a/client/src/components/NewMetricForm.jsx
+++ b/client/src/components/NewMetricForm.jsx
@@ -104,7 +104,9 @@ const NewMetricForm = () => {
           <div className="mt-2.5 flex items-center">
             <label htmlFor="metric-query" className="inline-block w-1/3 text-center mr-5">
               <p>Query to retrieve data:</p>
-              <p className="text-sm italic">Do not include semicolon. Query should result in <code>user_id</code>, <code>timestamp</code>, and <code>value</code> columns</p>
+              <p className="text-sm italic">Do not include semicolon.</p>
+              <p className="text-sm italic">If the metric is a <span className="font-bold">Binomial</span> type, the query should result in <code>user_id</code> and <code>timestamp</code> columns.</p>
+              <p className="text-sm italic">The query should result in <code>user_id</code>, <code>timestamp</code>, and <code>value</code> columns for all other types.</p>
             </label>
             <textarea id="metric-query" rows={6} cols={35} value={query} onChange={(e) => setQuery(e.target.value)} className="border border-slate rounded-lg p-2" />
           </div>


### PR DESCRIPTION
New instructions for adding a new metric's query string:
![image](https://user-images.githubusercontent.com/59182147/158933316-e846d0a7-9a15-4b32-b76c-7dfced5a3522.png)
New instructions for adding a database connection query string:
![image](https://user-images.githubusercontent.com/59182147/158933366-a3222314-7235-49fb-812a-41f2f6389570.png)
Backend verification was already tweaked in previous pull requests.