### PR TITLE
Moved hash_offset assignment to flag instead of expt

### DIFF
--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -114,13 +114,11 @@ const getExperimentsForFlag = async (req, res, next) => {
 
 const createExperiment = async (req, res, next) => {
   try {
-    const hash_offset = Math.floor(Math.random() * 100);
     const exptObj = {
       flag_id: req.body.flag_id,
       duration: req.body.duration,
       name: req.body.name || '',
       description: req.body.description || '',
-      hash_offset
     };
     const newExpt = await experimentsTable.insertRow(exptObj);
     // Add each metric_id to experiment_metrics with the experiment_id

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -15,18 +15,18 @@ const createNewFlagObj = ({
   percentage_split,
   status,
   is_experiment,
-  app_id,
 }) => {
+  const hash_offset = Math.floor(Math.random() * 100);
   const now = getNowString();
   return {
     name: name,
-    app_id: app_id || null,
     description: description || "",
     percentage_split: percentage_split || 100,
     status: status || false,
     is_experiment: is_experiment || false,
     date_created: now,
     is_deleted: false,
+    hash_offset
   };
 };
 


### PR DESCRIPTION
We're moving the hash_offset to the flag, since it will help randomize who gets flags depending on their rollout, for the same reasons we wanted to do it on the experiments.