### PR TITLE
Deleting flag sets is_deleted to TRUE 

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -37,7 +37,7 @@ const getAllFlags = async (req, res, next) => {
     if (req.query.prov) {
       data = await getFlagsForWebhook();
     } else {
-      data = await flagTable.getAllRows();
+      data = await flagTable.getAllRowsNotDeleted();
 
       if (!data) {
         throw new Error(
@@ -111,11 +111,11 @@ const editFlag = async (req, res, next) => {
 const deleteFlag = async (req, res, next) => {
   const id = req.params.id;
   try {
-    const result = await flagTable.deleteRow({ id });
-    if (result.rows.length === 0)
+    const result = await flagTable.editRow({ is_deleted: true }, { id });
+    if (!result)
       throw new Error(`Flag with the id of ${id} doesn't exist`);
 
-    const deletedFlagName = result.rows[0].name;
+    const deletedFlagName = result.name;
     req.update = true;
 
     res


### PR DESCRIPTION
The `flagsController.deleteFlag` now just edits a flag's `is_deleted` property to FALSE.
- I think this should still be a DELETE request from the frontend API, but correct me if you think it should be a PUT now.

`flagsController.getAllFlags` now uses the `flagTable.getAllRowsNotDeleted()` method (if the query isn't from the provider), so that deleted flags no longer show up.