### PR TITLE
Visualization of experiment results

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "apexcharts": "^3.33.2",
         "axios": "^0.26.0",
         "react": "^17.0.2",
+        "react-apexcharts": "^1.4.0",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.6",
         "react-router-dom": "^6.2.2",
@@ -13219,6 +13220,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-apexcharts": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.4.0.tgz",
+      "integrity": "sha512-DrcMV4aAMrUG+n6412yzyATWEyCDWlpPBBhVbpzBC4PDeuYU6iF84SmExbck+jx5MUm4U5PM3/T307Mc3kzc9Q==",
+      "dependencies": {
+        "prop-types": "^15.5.7"
+      },
+      "peerDependencies": {
+        "apexcharts": "^3.18.0",
+        "react": ">=0.13"
+      }
+    },
     "node_modules/react-app-polyfill": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
@@ -25752,6 +25765,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-apexcharts": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.4.0.tgz",
+      "integrity": "sha512-DrcMV4aAMrUG+n6412yzyATWEyCDWlpPBBhVbpzBC4PDeuYU6iF84SmExbck+jx5MUm4U5PM3/T307Mc3kzc9Q==",
+      "requires": {
+        "prop-types": "^15.5.7"
       }
     },
     "react-app-polyfill": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
+        "apexcharts": "^3.33.2",
         "axios": "^0.26.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -4339,6 +4340,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.33.2.tgz",
+      "integrity": "sha512-GkHZ3o36ZT/jSBh5y1pxxRzwM3tvtladtkcUTfXwP0wYAHK8Qj0X4ZPsupP7emRIjhOVpGsCxW9xeO3F5w+AOQ==",
+      "dependencies": {
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/arg": {
@@ -14719,6 +14733,89 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "dependencies": {
+        "svg.js": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha1-iqmUawqOJ4V6XEChDrpAkeVpHxI=",
+      "dependencies": {
+        "svg.js": ">=2.3.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha1-kQCOFROJ3ZIwd5/L5uLJo2LRwgM=",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA=="
+    },
+    "node_modules/svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "dependencies": {
+        "svg.js": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "dependencies": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js/node_modules/svg.select.js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "dependencies": {
+        "svg.js": "^2.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -19309,6 +19406,19 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apexcharts": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.33.2.tgz",
+      "integrity": "sha512-GkHZ3o36ZT/jSBh5y1pxxRzwM3tvtladtkcUTfXwP0wYAHK8Qj0X4ZPsupP7emRIjhOVpGsCxW9xeO3F5w+AOQ==",
+      "requires": {
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "arg": {
@@ -26772,6 +26882,70 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+    },
+    "svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "requires": {
+        "svg.js": "^2.0.1"
+      }
+    },
+    "svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha1-iqmUawqOJ4V6XEChDrpAkeVpHxI=",
+      "requires": {
+        "svg.js": ">=2.3.x"
+      }
+    },
+    "svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha1-kQCOFROJ3ZIwd5/L5uLJo2LRwgM=",
+      "requires": {
+        "svg.js": "^2.2.5"
+      }
+    },
+    "svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA=="
+    },
+    "svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "requires": {
+        "svg.js": "^2.4.0"
+      }
+    },
+    "svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "requires": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "dependencies": {
+        "svg.select.js": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+          "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+          "requires": {
+            "svg.js": "^2.2.5"
+          }
+        }
+      }
+    },
+    "svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "requires": {
+        "svg.js": "^2.6.5"
+      }
     },
     "svgo": {
       "version": "1.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "apexcharts": "^3.33.2",
     "axios": "^0.26.0",
     "react": "^17.0.2",
+    "react-apexcharts": "^1.4.0",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "apexcharts": "^3.33.2",
     "axios": "^0.26.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -46,9 +46,14 @@ a:hover {
 }
 
 th, td {
-  border-width: 1px;
-  border-color:#0C182E;
+  /* border-width: 1px; */
+  text-align: center;
   padding: 15px;
+}
+
+tr {
+  border-width: 1px;
+  border-color:#94a3b8;
 }
 
 .toggle {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -43,6 +43,7 @@ a:hover {
   padding: 10px 25px;
   margin: 15px;
   font-weight: bold;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 th, td {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -45,6 +45,12 @@ a:hover {
   font-weight: bold;
 }
 
+th, td {
+  border-width: 1px;
+  border-color:#0C182E;
+  padding: 15px;
+}
+
 .toggle {
   position: relative;
   display: inline-block;

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -33,3 +33,15 @@ export function editExperiment(exptId, updatedFields) {
 export function editExperimentSuccess(editedExpt) {
   return { type: "EDIT_EXPERIMENT_SUCCESS", editedExpt };
 }
+
+export function updateStats(id) {
+  return function(dispatch) {
+    apiClient.updateStats(id, data => {
+      dispatch(updateStatsSuccess(data));
+    });
+  }
+}
+
+export function updateStatsSuccess(stats) {
+  return { type: "UPDATE_STATS_SUCCESS", stats };
+}

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -37,11 +37,12 @@ export function editExperimentSuccess(editedExpt) {
 export function updateStats(id) {
   return function(dispatch) {
     apiClient.updateStats(id, data => {
+      console.log(data);
       dispatch(updateStatsSuccess(data));
     });
   }
 }
 
-export function updateStatsSuccess(stats) {
-  return { type: "UPDATE_STATS_SUCCESS", stats };
+export function updateStatsSuccess(metrics) {
+  return { type: "UPDATE_STATS_SUCCESS", metrics };
 }

--- a/client/src/components/ExperimentInfo.jsx
+++ b/client/src/components/ExperimentInfo.jsx
@@ -1,36 +1,75 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import EditExperiment from "./EditExperiment";
-import ExposuresChart from './ExposuresChart';
-import ExperimentResults from './ExperimentResults';
+import ExposuresChart from "./ExposuresChart";
+import ExperimentResults from "./ExperimentResults";
 
 const ExperimentInfo = ({ data, allMetrics }) => {
-  const { id, name, description, duration, date_started, date_ended, metrics } = data;
+  const { id, name, description, duration, date_started, date_ended, metrics } =
+    data;
   const [isEditing, setIsEditing] = useState(false);
   const startDate = new Date(date_started).toLocaleDateString("en-US");
-  const endDate = date_ended ? new Date(date_ended).toLocaleDateString("en-US") : "Present";
-  const metricsNames = metrics.map((metric) => {
-    return allMetrics.find(m => m.id === metric.metric_id).name
-  }).join(", ");
-
+  const endDate = date_ended
+    ? new Date(date_ended).toLocaleDateString("en-US")
+    : "Present";
+  const metricsNames = metrics
+    .map((metric) => {
+      return allMetrics.find((m) => m.id === metric.metric_id).name;
+    })
+    .join(", ");
 
   return (
     <div className="border border-dashed border-primary-oxfordblue rounded p-5 my-4">
       {!isEditing ? (
         <div className="flex flex-col items-center">
           <div className="flex justify-between items-center w-full">
-            <h2 className="text-primary-violet text-lg">Experiment from {startDate} to {endDate}</h2>
-            {!date_ended && <button className="bg-primary-turquoise text-primary-offwhite rounded-lg py-1.5 px-6 ml-2" type="button" onClick={() => setIsEditing(true)}>Edit Experiment</button>}
+            <h2 className="text-primary-violet text-lg">
+              Experiment from <span className="font-bold">{startDate}</span> to <span className="font-bold">{endDate}</span>
+            </h2>
+            {!date_ended && (
+              <button
+                className="bg-slate text-primary-offwhite rounded-lg py-1.5 px-6 ml-2"
+                type="button"
+                onClick={() => setIsEditing(true)}
+              >
+                Edit Experiment
+              </button>
+            )}
           </div>
-          <p>ID: <span className="font-bold">{id}</span></p>
-          {name && <p>Name: <span className="font-bold">{name}</span></p>}
-          <p>Duration: <span className="font-bold">{duration + " days"}</span></p>
-          {description && <p>Description: <span className="font-bold">{description}</span></p>}
-          <p>Metrics measured: <span className="font-bold">{metricsNames}</span></p>
+          <div className="w-full p-8 m-5 shadow-md">
+            <div>
+              <div className="inline-block w-1/2 text-right pr-10">ID:</div>
+              <span className="font-bold">{id}</span>
+            </div>
+            {name && (
+              <div>
+                <div className="inline-block w-1/2 text-right pr-10">Name:</div>
+                <span className="font-bold">{name}</span>
+              </div>
+            )}
+            <div>
+              <div className="inline-block w-1/2 text-right pr-10">Duration:</div>
+              <span className="font-bold">{duration + " days"}</span>
+            </div>
+            {description && (
+              <div>
+                <div className="inline-block w-1/2 text-right pr-10">Description:</div>
+                <span className="font-bold">{description}</span>
+              </div>
+            )}
+            <div>
+              <div className="inline-block w-1/2 text-right pr-10">Metrics measured:</div>
+              <span className="font-bold">{metricsNames}</span>
+            </div>
+          </div>
           <ExposuresChart id={id} />
           <ExperimentResults id={id} />
         </div>
       ) : (
-        <EditExperiment setIsEditing={setIsEditing} allMetrics={allMetrics} {...data}/>
+        <EditExperiment
+          setIsEditing={setIsEditing}
+          allMetrics={allMetrics}
+          {...data}
+        />
       )}
     </div>
   );

--- a/client/src/components/ExperimentInfo.jsx
+++ b/client/src/components/ExperimentInfo.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { useDispatch } from "react-redux";
-import { updateStats } from '../actions/exptActions';
 import EditExperiment from "./EditExperiment";
+import ExposuresChart from './ExposuresChart';
+import ExperimentResults from './ExperimentResults';
 
 const ExperimentInfo = ({ data, allMetrics }) => {
   const { id, name, description, duration, date_started, date_ended, metrics } = data;
@@ -11,16 +11,12 @@ const ExperimentInfo = ({ data, allMetrics }) => {
   const metricsNames = metrics.map((metric) => {
     return allMetrics.find(m => m.id === metric.metric_id).name
   }).join(", ");
-  const dispatch = useDispatch();
 
-  const handleRefreshResults = () => {
-    dispatch(updateStats(id));
-  };
 
   return (
     <div className="border border-dashed border-primary-oxfordblue rounded p-5 my-4">
       {!isEditing ? (
-        <>
+        <div className="flex flex-col items-center">
           <div className="flex justify-between items-center w-full">
             <h2 className="text-primary-violet text-lg">Experiment from {startDate} to {endDate}</h2>
             {!date_ended && <button className="bg-primary-turquoise text-primary-offwhite rounded-lg py-1.5 px-6 ml-2" type="button" onClick={() => setIsEditing(true)}>Edit Experiment</button>}
@@ -30,16 +26,12 @@ const ExperimentInfo = ({ data, allMetrics }) => {
           <p>Duration: <span className="font-bold">{duration + " days"}</span></p>
           {description && <p>Description: <span className="font-bold">{description}</span></p>}
           <p>Metrics measured: <span className="font-bold">{metricsNames}</span></p>
-          <h3 className="font-bold">Exposures</h3>
-          <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
-        </>
-    ) : (
-      <>
+          <ExposuresChart id={id} />
+          <ExperimentResults id={id} />
+        </div>
+      ) : (
         <EditExperiment setIsEditing={setIsEditing} allMetrics={allMetrics} {...data}/>
-      </>
-    )
-      }
-
+      )}
     </div>
   );
 };

--- a/client/src/components/ExperimentInfo.jsx
+++ b/client/src/components/ExperimentInfo.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { useDispatch } from "react-redux";
+import { updateStats } from '../actions/exptActions';
 import EditExperiment from "./EditExperiment";
 
 const ExperimentInfo = ({ data, allMetrics }) => {
@@ -9,7 +11,11 @@ const ExperimentInfo = ({ data, allMetrics }) => {
   const metricsNames = metrics.map((metric) => {
     return allMetrics.find(m => m.id === metric.metric_id).name
   }).join(", ");
+  const dispatch = useDispatch();
 
+  const handleRefreshResults = () => {
+    dispatch(updateStats(id));
+  };
 
   return (
     <div className="border border-dashed border-primary-oxfordblue rounded p-5 my-4">
@@ -24,7 +30,8 @@ const ExperimentInfo = ({ data, allMetrics }) => {
           <p>Duration: <span className="font-bold">{duration + " days"}</span></p>
           {description && <p>Description: <span className="font-bold">{description}</span></p>}
           <p>Metrics measured: <span className="font-bold">{metricsNames}</span></p>
-          <p>Details about experiment analysis, charts and stats go here</p>
+          <h3 className="font-bold">Exposures</h3>
+          <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
         </>
     ) : (
       <>

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Chart from "react-apexcharts";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { updateStats } from '../actions/exptActions';
 
 const ExperimentResults = ({ id }) => {

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -1,22 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Chart from "react-apexcharts";
 import { useSelector, useDispatch } from "react-redux";
 import { updateStats } from '../actions/exptActions';
 
 const ExperimentResults = ({ id }) => {
+  const [ results, setResults ] = useState();
   const dispatch = useDispatch();
+
 
   const handleRefreshResults = () => {
     dispatch(updateStats(id));
   };
 
   return (
-    <div>
-      <div>
+    <div className="w-full">
+      <div className="flex justify-between items-center">
         <h3 className="text-xl font-bold text-center">Results</h3>
         <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
       </div>
+      {results && (
+          <div>
 
+          </div>
+        )}
+        {!results && <p>No results yet. Click "Refresh Results" when ready.</p>}
     </div>
   );
 };

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -5,6 +5,7 @@ import MetricResultRow from './MetricResultRow';
 
 const ExperimentResults = ({ id }) => {
   const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
+  console.log(metrics);
   const hasResult = metrics.find(metric => metric.p_value !== null);
   const dispatch = useDispatch();
 

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -5,7 +5,6 @@ import MetricResultRow from './MetricResultRow';
 
 const ExperimentResults = ({ id }) => {
   const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
-  console.log(metrics);
   const hasResult = metrics.find(metric => metric.p_value !== null);
   const dispatch = useDispatch();
 

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Chart from "react-apexcharts";
+import { useDispatch } from "react-redux";
+import { updateStats } from '../actions/exptActions';
+
+const ExperimentResults = ({ id }) => {
+  const dispatch = useDispatch();
+
+  const handleRefreshResults = () => {
+    dispatch(updateStats(id));
+  };
+
+  return (
+    <div>
+      <div>
+        <h3 className="text-xl font-bold text-center">Results</h3>
+        <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
+      </div>
+
+    </div>
+  );
+};
+
+export default ExperimentResults;

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -53,7 +53,7 @@ const ExperimentResults = ({ id }) => {
           </tbody>
         </table>
       )}
-      {!hasResult && <p>No results yet. Click "Refresh Results" when ready.</p>}
+      {!hasResult && <p>No results to see yet! Click <span className="italic">Refresh Results</span> after there is sufficient sample size and the experiment has been running for enough time.</p>}
     </div>
   );
 };

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -6,6 +6,7 @@ import { updateStats } from '../actions/exptActions';
 const ExperimentResults = ({ id }) => {
   const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
   console.log(metrics);
+  const hasResult = metrics.find(metric => metric.p_value !== null);
   const dispatch = useDispatch();
 
   const handleRefreshResults = () => {
@@ -18,7 +19,7 @@ const ExperimentResults = ({ id }) => {
         <h3 className="text-xl font-bold text-center">Results</h3>
         <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
       </div>
-      {metrics.length > 0 && (
+      {hasResult && (
         <table className="w-full border border-primary-slate">
           <thead>
             <tr>
@@ -52,7 +53,7 @@ const ExperimentResults = ({ id }) => {
           </tbody>
         </table>
       )}
-      {metrics.length === 0 && <p>No results yet. Click "Refresh Results" when ready.</p>}
+      {!hasResult && <p>No results yet. Click "Refresh Results" when ready.</p>}
     </div>
   );
 };

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -20,8 +20,8 @@ const ExperimentResults = ({ id }) => {
         <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
       </div>
       {hasResult && (
-        <table className="w-full border border-primary-slate">
-          <thead>
+        <table className="w-full shadow-md">
+          <thead className="bg-primary-black text-primary-offwhite">
             <tr>
               <th>Metric</th>
               <th>Control Group Avg</th>

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -4,9 +4,9 @@ import { useSelector, useDispatch } from "react-redux";
 import { updateStats } from '../actions/exptActions';
 
 const ExperimentResults = ({ id }) => {
-  const [ results, setResults ] = useState();
+  const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
+  console.log(metrics);
   const dispatch = useDispatch();
-
 
   const handleRefreshResults = () => {
     dispatch(updateStats(id));
@@ -18,12 +18,41 @@ const ExperimentResults = ({ id }) => {
         <h3 className="text-xl font-bold text-center">Results</h3>
         <button onClick={handleRefreshResults} className="btn bg-primary-violet">Refresh Results</button>
       </div>
-      {results && (
-          <div>
-
-          </div>
-        )}
-        {!results && <p>No results yet. Click "Refresh Results" when ready.</p>}
+      {metrics.length > 0 && (
+        <table className="w-full border border-primary-slate">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Control Group Avg</th>
+              <th>Test Group Avg</th>
+              <th>P-Value</th>
+              <th>Percent Difference Confidence Interval</th>
+            </tr>
+          </thead>
+          <tbody >
+            {metrics.map(metric => {
+              return (
+                <tr key={metric.metric_id} className="border">
+                  <td>{metric.name}</td>
+                  <td>{metric.mean_control.toFixed(2)}</td>
+                  <td>{metric.mean_test.toFixed(2)}</td>
+                  <td>{metric.p_value.toFixed(4)}</td>
+                  <td>
+                    {metric.interval_start ? (
+                      <div>
+                        Chart: {(metric.interval_start * 100).toFixed(1)}% to {(metric.interval_end * 100).toFixed(1)}%
+                      </div>
+                    ) : (
+                      <p>No interval for binomial metrics</p>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+      {metrics.length === 0 && <p>No results yet. Click "Refresh Results" when ready.</p>}
     </div>
   );
 };

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import Chart from "react-apexcharts";
+import React from 'react';
 import { useSelector, useDispatch } from "react-redux";
 import { updateStats } from '../actions/exptActions';
+import MetricResultRow from './MetricResultRow';
 
 const ExperimentResults = ({ id }) => {
   const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
@@ -31,25 +31,7 @@ const ExperimentResults = ({ id }) => {
             </tr>
           </thead>
           <tbody >
-            {metrics.map(metric => {
-              return (
-                <tr key={metric.metric_id} className="border">
-                  <td>{metric.name}</td>
-                  <td>{metric.mean_control.toFixed(2)}</td>
-                  <td>{metric.mean_test.toFixed(2)}</td>
-                  <td>{metric.p_value.toFixed(4)}</td>
-                  <td>
-                    {metric.interval_start ? (
-                      <div>
-                        Chart: {(metric.interval_start * 100).toFixed(1)}% to {(metric.interval_end * 100).toFixed(1)}%
-                      </div>
-                    ) : (
-                      <p>No interval for binomial metrics</p>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
+            {metrics.map(metric => <MetricResultRow key={metric.metric_id} { ...metric } />)}
           </tbody>
         </table>
       )}

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -2,14 +2,20 @@ import React from 'react';
 import Chart from "react-apexcharts";
 
 const ExposuresChart = ({ id }) => {
-  const series = [{ name: "exposures", data: [5, 10, 20, 35, 50, 70] }];
+  const series = [
+    { name: "control", data: [5, 10, 20, 35, 50, 70] },
+    { name: "test", data: [6, 9, 19, 36, 51, 69] }
+  ];
   const chartOptions = {
     chart: { id },
     xaxis: {
       categories: ['2022-03-09', '2022-03-10', '2022-03-11', '2022-03-12', '2022-03-13', '2022-03-14']
     },
-    title: { text: "Exposures to Experiment Over Time" },
-    colors: ['#07C0C5']
+    title: { text: "Total Exposures to Experiment (Sample Size)" },
+    colors: ['#07C0C5', '#B94E9C'],
+    stroke: {
+      width: 1.5
+    }
   };
 
   return (
@@ -18,7 +24,7 @@ const ExposuresChart = ({ id }) => {
         options={chartOptions}
         series={series}
         type="line"
-        width="400"
+        width="450"
       />
     </div>
   );

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import Chart from "react-apexcharts";
+import { useSelector } from "react-redux";
 
 const ExposuresChart = ({ id }) => {
+  const exptData = useSelector((state) => state.experiments.find(expt => expt.id === id));
+  console.log(exptData);
+  const controlDates = Object.keys(exptData.exposuresControl).sort();
+  console.log(controlDates);
+  const controlVals = controlDates.map(date => exptData.exposuresControl[date]);
+  console.log(controlVals);
+  const testDates = Object.keys(exptData.exposuresTest).sort();
+  const testVals = testDates.map(date => exptData.exposuresTest[date]);
   const series = [
-    { name: "control", data: [5, 10, 20, 35, 50, 70] },
-    { name: "test", data: [6, 9, 19, 36, 51, 69] }
+    { name: "control", data: controlVals },
+    { name: "test", data: testVals }
   ];
   const chartOptions = {
     chart: { id },
     xaxis: {
-      categories: ['2022-03-09', '2022-03-10', '2022-03-11', '2022-03-12', '2022-03-13', '2022-03-14']
+      categories: controlDates.map(date => new Date(date).toLocaleDateString('en-US'))
     },
     title: { text: "Total Exposures to Experiment (Sample Size)" },
     colors: ['#07C0C5', '#B94E9C'],

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 
 const ExposuresChart = ({ id }) => {
   const exptData = useSelector((state) => state.experiments.find(expt => expt.id === id));
-  console.log(exptData);
   const controlDates = Object.keys(exptData.exposuresControl).sort();
   const controlVals = controlDates.map(date => exptData.exposuresControl[date]);
   const testDates = Object.keys(exptData.exposuresTest).sort();

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Chart from "react-apexcharts";
+
+const ExposuresChart = ({ id }) => {
+  const series = [{ name: "exposures", data: [5, 10, 20, 35, 50, 70] }];
+  const chartOptions = {
+    chart: { id },
+    xaxis: {
+      categories: ['2022-03-09', '2022-03-10', '2022-03-11', '2022-03-12', '2022-03-13', '2022-03-14']
+    },
+    title: { text: "Exposures to Experiment Over Time" },
+    colors: ['#07C0C5']
+  };
+
+  return (
+    <div className="m-5">
+      <Chart
+        options={chartOptions}
+        series={series}
+        type="line"
+        width="400"
+      />
+    </div>
+  );
+};
+
+export default ExposuresChart;

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -6,9 +6,7 @@ const ExposuresChart = ({ id }) => {
   const exptData = useSelector((state) => state.experiments.find(expt => expt.id === id));
   console.log(exptData);
   const controlDates = Object.keys(exptData.exposuresControl).sort();
-  console.log(controlDates);
   const controlVals = controlDates.map(date => exptData.exposuresControl[date]);
-  console.log(controlVals);
   const testDates = Object.keys(exptData.exposuresTest).sort();
   const testVals = testDates.map(date => exptData.exposuresTest[date]);
   const series = [

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 const ExposuresChart = ({ id }) => {
   const exptData = useSelector((state) => state.experiments.find(expt => expt.id === id));
   if (!exptData.exposuresControl || !exptData.exposuresTest) {
-    return <p>No exposures yet</p>;
+    return <p>No exposure data yet</p>;
   }
 
   let controlDates  = Object.keys(exptData.exposuresControl).sort();;

--- a/client/src/components/ExposuresChart.jsx
+++ b/client/src/components/ExposuresChart.jsx
@@ -4,10 +4,15 @@ import { useSelector } from "react-redux";
 
 const ExposuresChart = ({ id }) => {
   const exptData = useSelector((state) => state.experiments.find(expt => expt.id === id));
-  const controlDates = Object.keys(exptData.exposuresControl).sort();
-  const controlVals = controlDates.map(date => exptData.exposuresControl[date]);
-  const testDates = Object.keys(exptData.exposuresTest).sort();
-  const testVals = testDates.map(date => exptData.exposuresTest[date]);
+  if (!exptData.exposuresControl || !exptData.exposuresTest) {
+    return <p>No exposures yet</p>;
+  }
+
+  let controlDates  = Object.keys(exptData.exposuresControl).sort();;
+  let testDates = Object.keys(exptData.exposuresTest).sort();;
+  let controlVals = controlDates.map(date => exptData.exposuresControl[date]);;
+  let testVals = testDates.map(date => exptData.exposuresTest[date]);;
+
   const series = [
     { name: "control", data: controlVals },
     { name: "test", data: testVals }

--- a/client/src/components/MetricResultRow.jsx
+++ b/client/src/components/MetricResultRow.jsx
@@ -81,7 +81,7 @@ const MetricResultRow = ({ metric_id, name, type, mean_control, mean_test, p_val
             />
           </div>
         ) : (
-          <p>No interval for binomial metrics</p>
+          <p>N/A</p>
         )}
       </td>
     </tr>

--- a/client/src/components/MetricResultRow.jsx
+++ b/client/src/components/MetricResultRow.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Chart from "react-apexcharts";
+
+const MetricResultRow = ({ metric_id, name, type, mean_control, mean_test, p_value, interval_start, interval_end }) => {
+  const formatNum = (type, num) => {
+    if (type === 'revenue') {
+      return `$${num.toFixed(2)}`
+    }
+    if (type === 'binomial') {
+      return `${(num * 100).toFixed(2)}%`;
+    }
+    return num.toFixed(2);
+  };
+
+  const chartOptions = {
+    chart: {
+      id: metric_id,
+      toolbar: {
+        show: false
+      },
+    },
+    colors: ['#07C0C5', '#B94E9C'],
+    plotOptions: {
+      bar: {
+        horizontal: true,
+      }
+    },
+    yaxis: {
+      decimalsInFloat: 2,
+      min: (Math.floor(interval_start * 100) > 0) ? -1 : (Math.floor(interval_start * 100) - 5),
+      max: (Math.floor(interval_end * 100) < 0) ? 1 : (Math.floor(interval_end * 100) + 5),
+      // labels: {
+      //   formatter: function(val, index) { return `${val}%` }
+      // }
+    },
+    xaxis: {
+      type: 'numeric',
+      tickAmount: 3,
+      labels: {
+        hideOverlappingLabels: true,
+        formatter: function(val, index) { return `${Math.floor(val)}%` }
+      }
+    },
+    annotations: {
+      xaxis: [{
+        x: 0,
+        borderColor: '#B94E9C'
+      }],
+    },
+    tooltip: {
+      x: {
+        formatter: function(val, opt) { return `${Math.floor(val)}%` }
+      }
+    }
+  };
+
+  const series = [{
+    data: [
+      { x: 'Change', y: [interval_start * 100, interval_end * 100] }
+    ]
+  }];
+
+  return (
+    <tr key={metric_id}>
+      <td className="font-bold">{name}</td>
+      <td>{formatNum(type, mean_control)}</td>
+      <td>{formatNum(type, mean_test)}</td>
+      {p_value < 0.05 ? (
+        <td><p className="font-bold text-primary-turquoise">Significant</p>{p_value.toFixed(4)}</td>
+      ) : (
+        <td><p>Not significant</p>{p_value.toFixed(4)}</td>
+      )}
+      <td>
+        {interval_start ? (
+          <div>
+            <Chart options={chartOptions}
+              series={series}
+              type="rangeBar"
+              width="300"
+              height="100"
+            />
+          </div>
+        ) : (
+          <p>No interval for binomial metrics</p>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+export default MetricResultRow;

--- a/client/src/components/MetricResultRow.jsx
+++ b/client/src/components/MetricResultRow.jsx
@@ -1,12 +1,21 @@
-import React from 'react';
+import React from "react";
 import Chart from "react-apexcharts";
 
-const MetricResultRow = ({ metric_id, name, type, mean_control, mean_test, p_value, interval_start, interval_end }) => {
+const MetricResultRow = ({
+  metric_id,
+  name,
+  type,
+  mean_control,
+  mean_test,
+  p_value,
+  interval_start,
+  interval_end,
+}) => {
   const formatNum = (type, num) => {
-    if (type === 'revenue') {
-      return `$${num.toFixed(2)}`
+    if (type === "revenue") {
+      return `$${num.toFixed(2)}`;
     }
-    if (type === 'binomial') {
+    if (type === "binomial") {
       return `${(num * 100).toFixed(2)}%`;
     }
     return num.toFixed(2);
@@ -16,64 +25,86 @@ const MetricResultRow = ({ metric_id, name, type, mean_control, mean_test, p_val
     chart: {
       id: metric_id,
       toolbar: {
-        show: false
+        show: false,
       },
     },
-    colors: ['#07C0C5', '#B94E9C'],
+    colors: ["#07C0C5", "#B94E9C"],
     plotOptions: {
       bar: {
         horizontal: true,
-      }
+      },
     },
     yaxis: {
       decimalsInFloat: 2,
-      min: (Math.floor(interval_start * 100) > 0) ? -1 : (Math.floor(interval_start * 100) - 5),
-      max: (Math.floor(interval_end * 100) < 0) ? 1 : (Math.floor(interval_end * 100) + 5),
-      // labels: {
-      //   formatter: function(val, index) { return `${val}%` }
-      // }
+      min:
+        Math.floor(interval_start * 100) > 0
+          ? -1
+          : Math.floor(interval_start * 100) - 5,
+      max:
+        Math.floor(interval_end * 100) < 0
+          ? 1
+          : Math.floor(interval_end * 100) + 5
     },
     xaxis: {
-      type: 'numeric',
+      type: "numeric",
       tickAmount: 3,
       labels: {
         hideOverlappingLabels: true,
-        formatter: function(val, index) { return `${Math.floor(val)}%` }
-      }
+        formatter: function (val, index) {
+          return `${Math.floor(val)}%`;
+        },
+      },
     },
     annotations: {
-      xaxis: [{
-        x: 0,
-        borderColor: '#B94E9C'
-      }],
+      xaxis: [
+        {
+          x: 0,
+          borderColor: "#B94E9C",
+        },
+      ],
     },
     tooltip: {
       x: {
-        formatter: function(val, opt) { return `${Math.floor(val)}%` }
-      }
-    }
+        formatter: function (val, opt) {
+          return `${Math.floor(val)}%`;
+        },
+      },
+    },
   };
 
-  const series = [{
-    data: [
-      { x: 'Change', y: [interval_start * 100, interval_end * 100] }
-    ]
-  }];
+  const series = [
+    {
+      data: [{ x: "Change", y: [interval_start * 100, interval_end * 100] }],
+    },
+  ];
 
   return (
     <tr key={metric_id}>
       <td className="font-bold">{name}</td>
-      <td>{formatNum(type, mean_control)}</td>
-      <td>{formatNum(type, mean_test)}</td>
-      {p_value < 0.05 ? (
-        <td><p className="font-bold text-primary-turquoise">Significant</p>{p_value.toFixed(4)}</td>
-      ) : (
-        <td><p>Not significant</p>{p_value.toFixed(4)}</td>
+      <td>{mean_control ? formatNum(type, mean_control) : "No data yet"}</td>
+      <td>{mean_test ? formatNum(type, mean_test) : "No data yet"}</td>
+      {p_value &&
+        (p_value < 0.05 ? (
+          <td>
+            <p className="font-bold text-primary-turquoise">Significant</p>
+            {p_value.toFixed(4)}
+          </td>
+        ) : (
+          <td>
+            <p>Not significant</p>
+            {p_value.toFixed(4)}
+          </td>
+        ))}
+      {!p_value && (
+        <td>
+          <p>No data yet</p>
+        </td>
       )}
       <td>
         {interval_start ? (
           <div>
-            <Chart options={chartOptions}
+            <Chart
+              options={chartOptions}
               series={series}
               type="rangeBar"
               width="300"

--- a/client/src/lib/ApiClient.js
+++ b/client/src/lib/ApiClient.js
@@ -145,6 +145,13 @@ const apiClient = {
       .then(unwrapData)
       .then(callback)
       .catch(logError)
+  },
+  updateStats: function(exptId, callback) {
+    return axios
+      .put(`/api/experiments/${exptId}/analysis`)
+      .then(unwrapData)
+      .then(callback)
+      .catch(logError)
   }
 };
 

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -17,6 +17,16 @@ export default function experiments(state = [], action) {
 
       return newState;
     }
+    case "UPDATE_STATS_SUCCESS": {
+      let newState = [...state];
+      const exptId = action.metrics[0].experiment_id;
+      return newState.map(expt => {
+        if (expt.id === exptId) {
+          expt.metrics = action.metrics;
+        }
+        return expt;
+      });
+    }
     default: {
       return state;
     }

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -4,11 +4,22 @@ exports.EXPERIMENT_METRICS_TABLE_NAME = "experiment_metrics";
 exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.CONNECTION_TABLE_NAME = "connection";
-exports.GET_EXPT_METRICS_QUERY = `SELECT * FROM experiments e
+exports.GET_EXPT_METRICS_QUERY = `SELECT e.* ,
+                                    em.metric_id,
+                                    m.name,
+                                    m.type,
+                                    em.mean_test,
+                                    em.mean_control,
+                                    em.interval_start,
+                                    em.interval_end,
+                                    em.p_value
+                                FROM experiments e
                                  JOIN experiment_metrics em
-                                 ON e.id=em.experiment_id
+                                  ON e.id=em.experiment_id
+                                 JOIN metrics m
+                                  ON em.metric_id = m.id
                                  WHERE flag_id = $1
-                                 ORDER BY id DESC;`;
+                                 ORDER BY e.id DESC;`;
 exports.GET_EXPOSURES_ON_EXPT = `SELECT variant, num_users, date
                                  FROM exposures
                                  WHERE experiment_id = $1

--- a/server/constants/db.js
+++ b/server/constants/db.js
@@ -4,6 +4,21 @@ exports.EXPERIMENT_METRICS_TABLE_NAME = "experiment_metrics";
 exports.EXPOSURES_TABLE_NAME = "exposures";
 exports.METRICS_TABLE_NAME = "metrics";
 exports.CONNECTION_TABLE_NAME = "connection";
+exports.GET_METRIC_DATA = `
+  SELECT em.experiment_id,
+    em.metric_id,
+    m.name,
+    m.type,
+    em.mean_test,
+    em.mean_control,
+    em.interval_start,
+    em.interval_end,
+    em.p_value
+  FROM experiment_metrics em
+  JOIN metrics m
+    ON em.metric_id = m.id
+  WHERE em.experiment_id = $1
+`;
 exports.GET_EXPT_METRICS_QUERY = `SELECT e.* ,
                                     em.metric_id,
                                     m.name,

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -170,7 +170,7 @@ const editExperiment = async (req, res, next) => {
     } else {
       updatedExpt = await experimentsTable.getRow(id);
     }
-    const updatedMetrics = await experimentMetricsTable.getRowsWhere({ experiment_id: id });
+    const updatedMetrics = (await experimentMetricsTable.query(GET_METRIC_DATA, [ id ])).rows;
     updatedExpt.metrics = updatedMetrics;
     req.updatedExpt = updatedExpt;
     // If regular edit, not stopping experiment, just send back updated expt

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -1,5 +1,5 @@
 const PGTable = require("../db/PGTable");
-const { EXPERIMENTS_TABLE_NAME, EXPERIMENT_METRICS_TABLE_NAME, EXPOSURES_TABLE_NAME, GET_EXPT_METRICS_QUERY, GET_EXPOSURES_ON_EXPT } = require("../constants/db");
+const { EXPERIMENTS_TABLE_NAME, EXPERIMENT_METRICS_TABLE_NAME, EXPOSURES_TABLE_NAME, GET_EXPT_METRICS_QUERY, GET_EXPOSURES_ON_EXPT, GET_METRIC_DATA } = require("../constants/db");
 const { getNowString } = require("../utils");
 const { runAnalytics } = require('../lib/statistics');
 
@@ -200,7 +200,8 @@ const analyzeExperiment = async (req, res, next) => {
   const id = req.params.id;
   try {
     await runAnalytics(id);
-    res.status(200).send("Success");
+    const result = await experimentsTable.query(GET_METRIC_DATA, [ id ]);
+    res.status(200).send(result.rows);
   } catch (err) {
     console.log(err);
     res.status(500).send(err.message);

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -39,8 +39,8 @@ const separateMetricExperimentData = (metricExpt) => {
     metric_id,
     mean_test,
     mean_control,
-    interval_width_test,
-    interval_width_control,
+    interval_start,
+    interval_end,
     p_value,
     ...expt
   } = metricExpt;
@@ -49,8 +49,8 @@ const separateMetricExperimentData = (metricExpt) => {
     metric_id,
     mean_test,
     mean_control,
-    interval_width_test,
-    interval_width_control,
+    interval_start,
+    interval_end,
     p_value
   };
 

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -100,7 +100,7 @@ const getExperimentsForFlag = async (req, res, next) => {
     // attaches exposures to running experiment
     const runningExpt = experiments.find((expt) => expt.date_ended === null);
     if (runningExpt) {
-      let { rows: exposures } = await exposuresTable.query(GET_EXPOSURES_ON_EXPT, [1]);
+      let { rows: exposures } = await exposuresTable.query(GET_EXPOSURES_ON_EXPT, [ runningExpt.id ]);
 
       if (exposures.length > 0) {
         const exposuresTest = createExposureObj(exposures, "test")

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -42,6 +42,8 @@ const separateMetricExperimentData = (metricExpt) => {
     interval_start,
     interval_end,
     p_value,
+    name,
+    type,
     ...expt
   } = metricExpt;
 
@@ -51,7 +53,9 @@ const separateMetricExperimentData = (metricExpt) => {
     mean_control,
     interval_start,
     interval_end,
-    p_value
+    p_value,
+    name,
+    type
   };
 
   return [expt, metricObj];
@@ -97,15 +101,14 @@ const getExperimentsForFlag = async (req, res, next) => {
     const runningExpt = experiments.find((expt) => expt.date_ended === null);
     if (runningExpt) {
       let { rows: exposures } = await exposuresTable.query(GET_EXPOSURES_ON_EXPT, [1]);
+
       if (exposures.length > 0) {
-        console.log(String(exposures[1].date));
         const exposuresTest = createExposureObj(exposures, "test")
         const exposuresControl = createExposureObj(exposures, "control")
         runningExpt.exposuresTest = exposuresTest;
         runningExpt.exposuresControl = exposuresControl;
       }
     }
-
     res.status(200).send(experiments);
   } catch (err) {
     console.log(err);

--- a/server/controllers/exposuresController.js
+++ b/server/controllers/exposuresController.js
@@ -17,11 +17,6 @@ const backfillData = async (req, res, next) => {
   }
 };
 
-const getExposures = () => {
-
-};
-
 exports.backfillData = backfillData;
-exports.getExposures = getExposures;
 
 

--- a/server/controllers/exposuresController.js
+++ b/server/controllers/exposuresController.js
@@ -1,0 +1,27 @@
+const PGTable = require("../db/PGTable");
+const { EXPERIMENTS_TABLE_NAME, EXPERIMENT_METRICS_TABLE_NAME, EXPOSURES_TABLE_NAME, GET_EXPT_METRICS_QUERY, GET_EXPOSURES_ON_EXPT } = require("../constants/db");
+const { backfillExposures } = require('../lib/experimentExposures');
+
+const experimentsTable = new PGTable(EXPERIMENTS_TABLE_NAME);
+experimentsTable.init();
+
+const backfillData = async (req, res, next) => {
+  try {
+    const result = await experimentsTable.query("SELECT CURRENT_DATE - MIN(date_started) AS date_diff FROM experiments WHERE date_ended IS NULL");
+    const dayDiff = result.rows[0]['date_diff'];
+    await backfillExposures(dayDiff);
+    res.status(200).send("Successfully updated");
+  } catch (err) {
+    console.log(err);
+    res.status(500).send(err.message);
+  }
+};
+
+const getExposures = () => {
+
+};
+
+exports.backfillData = backfillData;
+exports.getExposures = getExposures;
+
+

--- a/server/lib/statistics.js
+++ b/server/lib/statistics.js
@@ -104,9 +104,9 @@ const updateStats = async (exptMetric) => {
   const exptQuery = await getExptQuery();
   const { query_string: metricQuery, type: metricType } = await getMetricData(metricId);
   if (metricType === 'binomial') {
-    calcDiscreteMetric(exptId, metricId, exptQuery, metricQuery);
+    await calcDiscreteMetric(exptId, metricId, exptQuery, metricQuery);
   } else {
-    calcContinuousMetric(exptId, metricId, exptQuery, metricQuery);
+    await calcContinuousMetric(exptId, metricId, exptQuery, metricQuery);
   }
 };
 
@@ -118,10 +118,9 @@ const runAnalytics = async (exptId) => {
     experiments = [ exptId ];
   }
   const exptMetrics = await getExptMetrics(experiments);
-  console.log(exptMetrics);
-  exptMetrics.forEach(combo => {
-    updateStats(combo);
-  });
+  for (let i = 0; i < exptMetrics.length; i++) {
+    await updateStats(exptMetrics[i]);
+  }
 };
 
 exports.runAnalytics = runAnalytics;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -4,6 +4,7 @@ const flagsController = require("../controllers/flagsController");
 const experimentController = require("../controllers/experimentController");
 const metricsController = require("../controllers/metricsController");
 const connectionController = require("../controllers/connectionController");
+const exposuresController = require("../controllers/exposuresController");
 const { validateNewFlag } = require("../validators/validators");
 // will implement later
 // const { validateSDKKey, validateNewFlag } = require("../validators/validators");
@@ -67,7 +68,9 @@ router.delete("/connection", connectionController.removeConnection);
 
 router.get("/connection", connectionController.testConnection);
 
-router.put("/experiments/exposures", experimentController.backfillData);
+router.put("/exposures", exposuresController.backfillData);
+
+router.get("/exposures/:id", exposuresController.getExposures);
 
 router.put("/experiments/:id/analysis", experimentController.analyzeExperiment);
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -70,8 +70,6 @@ router.get("/connection", connectionController.testConnection);
 
 router.put("/exposures", exposuresController.backfillData);
 
-router.get("/exposures/:id", exposuresController.getExposures);
-
 router.put("/experiments/:id/analysis", experimentController.analyzeExperiment);
 
 router.put("/analysis", experimentController.analyzeAll);


### PR DESCRIPTION
- Added line chart of exposures data (if there are no exposures, it says "No exposure data yet". 
- Added a table summary of the statistics for each metric on the experiment
- Similarly if there are no statistics data, it prompts the user to click the "Refresh results" button if they have enough sample size.
- The numbers are formatted according to the metrics' type (binomial returns a percentage, revenue adds a dollar sign) and rounded to 2 decimal places (I just thought that was a good amount of precision for most cases).
- In the p-value column, it will say "Significant" in green if it is below the alpha threshold (0.05).
- In the last column there is a chart showing the 95% confidence interval, and 0 is marked with a purple line. It's not as fancy as other tools, but I couldn't find a better way without using a paid product.
- You can hover over the charts to see the numbers for each data point
- I also restyled the portion at the top of the Experiment Info showing the duration, description, etc.

Example of a newly created experiment with no data yet:

![Newly created](https://user-images.githubusercontent.com/75290988/159104138-cf2817a5-6c60-45c2-b0a3-a6268967fa55.jpg)

Example of an experiment that has some data:

![expt_1](https://user-images.githubusercontent.com/75290988/159104145-6605d124-c53b-439b-857a-6cd3c3121170.jpg)

# Future work
- Will definitely add some explanations about best practices, and how to interpret each number. I'm not sure whether to put that right on the UI or just in the documentation. It's something they should only need to read once, not every time they see it, so I'm thinking about putting it mostly in documentation or an "FAQ" page?
- Thinking about adding the current sample size for each group somewhere. Not sure if that's necessary though since there's already the chart showing that.