### PR TITLE
Sdk webhook

### DIFF
--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -96,13 +96,13 @@ const getExperimentsForFlag = async (req, res, next) => {
   const flagId = req.params.id;
   try {
     let { rows: exptMetrics } = await experimentsTable.query(GET_EXPT_METRICS_QUERY, [flagId]);
-    const experiments = transformMetricExptData(exptMetrics);
+    const experiments = transformMetricExptData(exptMetrics); // transforms to redux-friendly format
     // attaches exposures to running experiment
     const runningExpt = experiments.find((expt) => expt.date_ended === null);
     if (runningExpt) {
       let { rows: exposures } = await exposuresTable.query(GET_EXPOSURES_ON_EXPT, [ runningExpt.id ]);
 
-      if (exposures.length > 0) {
+      if (exposures.length > 0) { // put exposures onto running experiment
         const exposuresTest = createExposureObj(exposures, "test")
         const exposuresControl = createExposureObj(exposures, "control")
         runningExpt.exposuresTest = exposuresTest;

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -80,7 +80,6 @@ const createFlag = async (req, res, next) => {
 
     try {
       const savedFlag = await flagTable.insertRow(newFlag);
-      req.update = true;
       res.status(200).send(savedFlag);
       next();
     } catch (e) {
@@ -99,7 +98,6 @@ const editFlag = async (req, res, next) => {
 
   try {
     const updatedFlag = await flagTable.editRow(updatedFields, { id });
-    req.update = true;
 
     res.status(200).send(updatedFlag);
     next();
@@ -116,7 +114,6 @@ const deleteFlag = async (req, res, next) => {
       throw new Error(`Flag with the id of ${id} doesn't exist`);
 
     const deletedFlagName = result.name;
-    req.update = true;
 
     res
       .status(200)
@@ -129,11 +126,10 @@ const deleteFlag = async (req, res, next) => {
 
 const sendFlagsWebhook = async (req, res, next) => {
   try {
-    await sendWebhook(req.flags);
-    console.log("webhook sent");
-    res.status(200);
+    await sendWebhook("/flags", req.flags);
+    console.log("flag webhook sent");
   } catch (err) {
-    console.log("Could not send webhook");
+    console.log("Could not send flag webhook");
   }
 };
 

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -129,7 +129,7 @@ const sendFlagsWebhook = async (req, res, next) => {
     await sendWebhook("/flags", req.flags);
     console.log("flag webhook sent");
   } catch (err) {
-    console.log("Could not send flag webhook");
+    console.log(err.message);
   }
 };
 

--- a/server/controllers/sdkKeyController.js
+++ b/server/controllers/sdkKeyController.js
@@ -11,7 +11,7 @@ const createKey = async (req, res, next) => {
   try {
     await keysTable.insertRow({ sdk_key: key });
     res.status(200).send(key);
-    req.sdk_key = key;
+    req.sdk_key = { key };
     next();
   } catch (err) {
     res.status(500).send("Error saving new key");
@@ -43,10 +43,10 @@ const removeKeys = async (req, res, next) => {
 
 const sendSdkWebhook = async (req, res, next) => {
   try {
-    await sendWebhook("/key", {key: req.sdk_key});
+    await sendWebhook("/key", req.sdk_key);
     console.log("SDK key webhook sent");
   } catch (err) {
-    console.log("Could not send SDK key webhook");
+    console.log(err.message);
   }
 };
 

--- a/server/controllers/sdkKeyController.js
+++ b/server/controllers/sdkKeyController.js
@@ -1,6 +1,7 @@
 const PGTable = require("../db/PGTable");
 const { KEYS_TABLE_NAME } = require("../constants/db");
 const { v4: uuidv4 } = require('uuid');
+const { sendWebhook } = require("../lib/sendWebhook.js");
 
 const keysTable = new PGTable(KEYS_TABLE_NAME);
 keysTable.init();
@@ -10,6 +11,8 @@ const createKey = async (req, res, next) => {
   try {
     await keysTable.insertRow({ sdk_key: key });
     res.status(200).send(key);
+    req.sdk_key = key;
+    next();
   } catch (err) {
     res.status(500).send("Error saving new key");
   }
@@ -38,6 +41,16 @@ const removeKeys = async (req, res, next) => {
   }
 }
 
+const sendSdkWebhook = async (req, res, next) => {
+  try {
+    await sendWebhook("/key", {key: req.sdk_key});
+    console.log("SDK key webhook sent");
+  } catch (err) {
+    console.log("Could not send SDK key webhook");
+  }
+};
+
 exports.createKey = createKey;
 exports.fetchKey = fetchKey;
 exports.removeKeys = removeKeys;
+exports.sendSdkWebhook = sendSdkWebhook;

--- a/server/lib/sendWebhook.js
+++ b/server/lib/sendWebhook.js
@@ -6,8 +6,7 @@ async function sendWebhook(path, data) {
   try {
     await axios.post(url, data);
   } catch (err) {
-    console.log(err);
-    throw new Error("Error sending webhook");
+    throw new Error(`Error sending webhook to ${path}`);
   }
 }
 

--- a/server/lib/sendWebhook.js
+++ b/server/lib/sendWebhook.js
@@ -1,10 +1,12 @@
 const axios = require("axios");
 require("dotenv").config();
 
-async function sendWebhook(data) {
+async function sendWebhook(path, data) {
+  const url = process.env.FLAG_PROVIDER_URL + path;
   try {
-    await axios.post(process.env.FLAG_PROVIDER_URL, data);
+    await axios.post(url, data);
   } catch (err) {
+    console.log(err);
     throw new Error("Error sending webhook");
   }
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -71,7 +71,12 @@ router.put("/experiments/:id/analysis", experimentController.analyzeExperiment);
 
 router.put("/analysis", experimentController.analyzeAll);
 
-router.post("/sdkKey", sdkKeyController.removeKeys, sdkKeyController.createKey);
+router.post(
+  "/sdkKey",
+  sdkKeyController.removeKeys,
+  sdkKeyController.createKey,
+  sdkKeyController.sendSdkWebhook
+);
 
 router.get("/sdkKey", sdkKeyController.fetchKey);
 


### PR DESCRIPTION
Created the `sdkKeyController.sendSdkWebhook` middleware that sends a newly created sdk key after our backend receives a POST "/sdkKey" request.
- It sends it in the format { key: "asdofiuvpoaipd"}

Altered the `lib/sendWebhook` function to take another parameter, `path`, which directs the request to the path argument passed in. In order for this to work, you must set your FLAG_PROVIDER_URL env variable to just the domain.
- Ex. FLAG_PROVIDER_URL = "http://localhost:5050" -> `sendWebhook("/key", req.sdk_key) sends a request to http://localhost:5050/key.
- I updated how the `flagsController` sends webhooks so it works with the new version of `lib/sendWebhook`.

I changed the error handling for `lib/sendWebhook` to now display `Error sending webhook to ${path}` when there's an error sending a webhook.

I also deleted some unnecesary logic in the flagsController.