### PR TITLE
Fixed: Refresh Statistics action was causing an error when new experiment had no data

### DIFF
--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -37,7 +37,6 @@ export function editExperimentSuccess(editedExpt) {
 export function updateStats(id) {
   return function(dispatch) {
     apiClient.updateStats(id, data => {
-      console.log(data);
       dispatch(updateStatsSuccess(data));
     });
   }

--- a/client/src/components/ExperimentResults.jsx
+++ b/client/src/components/ExperimentResults.jsx
@@ -5,7 +5,6 @@ import MetricResultRow from './MetricResultRow';
 
 const ExperimentResults = ({ id }) => {
   const metrics = useSelector((state) => state.experiments.find(expt => expt.id === id).metrics);
-  console.log(metrics);
   const hasResult = metrics.find(metric => metric.p_value !== null);
   const dispatch = useDispatch();
 

--- a/server/lib/statistics.js
+++ b/server/lib/statistics.js
@@ -38,6 +38,9 @@ const calcContinuousMetric = async (exptId, metricId, exptQuery, metricQuery) =>
     ORDER BY 1
   `;
   result = await eventDbQuery(query, exptId);
+  if (result.rows.length === 0) {
+    return;
+  }
   const [ controlGroup, testGroup ] = result.rows;
 
   const stat = ttest(
@@ -78,6 +81,10 @@ const calcDiscreteMetric = async (exptId, metricId, exptQuery, metricQuery) => {
   ORDER BY 1
   `;
   result = await eventDbQuery(query, exptId);
+  if (result.rows.length === 0) {
+    return;
+  }
+
   let obs = []
   result.rows.forEach(group => {
     let data = [ +group.count, +group.num_users - (+group.count) ];


### PR DESCRIPTION
- In the stats calculations, now returns early if there is no data returned from the query
- Also removed the extra console log statements