### PR TITLE
Fixed editExperiment to get exposures and automatically update UI

### DIFF
--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -25,7 +25,8 @@ export function createExperimentSuccess(newExpt) {
 export function editExperiment(exptId, updatedFields) {
   return function(dispatch) {
     apiClient.editExperiment(exptId, updatedFields, data => {
-      dispatch(editExperimentSuccess(data));
+      dispatch(updateStatsSuccess(data.stats))
+      dispatch(editExperimentSuccess(data.updatedExpt));
     });
   }
 }

--- a/client/src/components/experiments/ExperimentInfo.jsx
+++ b/client/src/components/experiments/ExperimentInfo.jsx
@@ -16,6 +16,7 @@ const ExperimentInfo = ({ data, allMetrics }) => {
       return allMetrics.find((m) => m.id === metric.metric_id).name;
     })
     .join(", ");
+    console.log(data);
 
   return (
     <div className="rounded p-5 mt-3 mb-16 shadow-xl border-2 border-slate">
@@ -61,7 +62,7 @@ const ExperimentInfo = ({ data, allMetrics }) => {
               <span className="font-bold">{metricsNames}</span>
             </div>
           </div>
-          <ExposuresChart id={id} />
+          {!date_ended && <ExposuresChart id={id} />}
           <ExperimentResults id={id} />
         </div>
       ) : (

--- a/client/src/components/experiments/ExperimentInfo.jsx
+++ b/client/src/components/experiments/ExperimentInfo.jsx
@@ -16,7 +16,6 @@ const ExperimentInfo = ({ data, allMetrics }) => {
       return allMetrics.find((m) => m.id === metric.metric_id).name;
     })
     .join(", ");
-    console.log(data);
 
   return (
     <div className="rounded p-5 mt-3 mb-16 shadow-xl border-2 border-slate">

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -16,7 +16,6 @@ export default function experiments(state = [], action) {
       return newState;
     }
     case "UPDATE_STATS_SUCCESS": {
-      console.log(action);
       let newState = [...state];
       const exptId = action.metrics[0].experiment_id;
       return newState.map(expt => {

--- a/client/src/reducers/experiments.js
+++ b/client/src/reducers/experiments.js
@@ -11,13 +11,12 @@ export default function experiments(state = [], action) {
       const indexOfEdited = newState.findIndex((expt) => (
         expt.id === action.editedExpt.id
       ));
-      const exposures = newState[indexOfEdited].exposures;
       newState[indexOfEdited] = action.editedExpt;
-      newState[indexOfEdited].exposures = exposures;
 
       return newState;
     }
     case "UPDATE_STATS_SUCCESS": {
+      console.log(action);
       let newState = [...state];
       const exptId = action.metrics[0].experiment_id;
       return newState.map(expt => {

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -177,13 +177,8 @@ const editExperiment = async (req, res, next) => {
     const updatedMetrics = (await experimentMetricsTable.query(GET_METRIC_DATA, [ id ])).rows;
     updatedExpt.metrics = updatedMetrics;
     req.updatedExpt = updatedExpt;
-    // If regular edit, not stopping experiment, just send back updated expt
-    // if (!updatedFields.date_ended) {
-    //   res.status(200).send(updatedExpt);
-    //   return;
-    // }
-    // Else if stopping experiment, go to analyzeExperiment()
-    next();
+
+    next(); // go to analyzeExperiment
   } catch (err) {
     console.log(err);
     res.status(500).send(err.message)


### PR DESCRIPTION
Adding exposures data to `editExperiment`
- Took the setting exposures on an experiment object logic and put it into `setExposuresOnExperiment`.
- Updated `getExperimentsForFlag` to use this new function.
- Used this function in `editExperiment` to fix the bug where we'd lose the exposure data every time we edited an experiment (unless we're stopping the experiment).
- Since we were getting back exposures every time, I changed the logic in the `experiments` reducer for "EDIT_EXPERIMENT_SUCCESS"

Changing `analyzeExperiment` to be called each time we call `editExperiment`, and to also send back the updated experiment if called with `editExperiment`. If called without `editExperiment` it just sends back the stats.
- This is why when I hit "stop experiment", the page wouldn't update, since the frontend wasn't getting back the new experiment object, just the stats object, thus the experiment wasn't being updated and it's `date_ended` == `null`
- Had to dispatch two actions from `exptActions.editExperiment`, one to dispatch the stats, the other to dispatch the experiment

I also made it so the exposure chart no longer shows if the experiment is not running.