### PR TITLE
More CSS

### DIFF
--- a/client/src/components/forms/EditFlagForm.jsx
+++ b/client/src/components/forms/EditFlagForm.jsx
@@ -130,9 +130,10 @@ const EditFlagForm = ({ setIsEditing, customAssignments }) => {
 
     setIsEditing(false);
   };
+  const underlineStyle = "underline underline-offset-4 mx-1 text-primary-violet hover:text-primaryDark-violet";
 
   return (
-    <div className="flex flex-col items-center border-b border-b-primary-oxfordblue py-8">
+    <div className="flex flex-col items-center py-8">
       <h2 className="font-bold text-xl text-primary-violet">Edit Flag</h2>
       <form className="w-full">
         <div className={FIELD_DIV_CSS}>
@@ -199,7 +200,7 @@ const EditFlagForm = ({ setIsEditing, customAssignments }) => {
             value={userToDelete}
             onChange={(e) => setUserToDelete(e.target.value)}
           />
-          <button className="underline underline-offset-4 mx-2 text-primary-violet hover:text-primaryDark-violet" type="button" onClick={handleDelete}>
+          <button className="font-bold text-primary-violet underline underline-offset-4 hover:no-underline hover:bg-primary-offwhite hover:text-primaryDark-violet py-2 px-4 rounded-md mx-2" type="button" onClick={handleDelete}>
             Delete
           </button>
         </div>
@@ -218,7 +219,7 @@ const EditFlagForm = ({ setIsEditing, customAssignments }) => {
             <option value={"true"} >Always On</option>
             <option value={"false"} >Always Off</option>
           </select>
-          <button className="underline underline-offset-4 mx-1 text-primary-violet hover:text-primaryDark-violet" type="button" onClick={handleAdd}>
+          <button className="font-bold text-primary-violet underline underline-offset-4 hover:no-underline hover:bg-primary-offwhite hover:text-primaryDark-violet py-2 px-4 rounded-md" type="button" onClick={handleAdd}>
             Add
           </button>
         </div>

--- a/client/src/components/forms/EditFlagForm.jsx
+++ b/client/src/components/forms/EditFlagForm.jsx
@@ -199,7 +199,7 @@ const EditFlagForm = ({ setIsEditing, customAssignments }) => {
             value={userToDelete}
             onChange={(e) => setUserToDelete(e.target.value)}
           />
-          <button className="btn bg-primary-violet hover:bg-primaryDark-violet mx-2" type="button" onClick={handleDelete}>
+          <button className="underline underline-offset-4 mx-2 text-primary-violet hover:text-primaryDark-violet" type="button" onClick={handleDelete}>
             Delete
           </button>
         </div>
@@ -218,12 +218,12 @@ const EditFlagForm = ({ setIsEditing, customAssignments }) => {
             <option value={"true"} >Always On</option>
             <option value={"false"} >Always Off</option>
           </select>
-          <button className="btn bg-primary-turquoise hover:bg-primaryDark-turquoise mx-1" type="button" onClick={handleAdd}>
+          <button className="underline underline-offset-4 mx-1 text-primary-violet hover:text-primaryDark-violet" type="button" onClick={handleAdd}>
             Add
           </button>
         </div>
       </form>
-      <div>
+      <div className="mt-8">
         <button
           className="btn bg-primary-turquoise hover:bg-primaryDark-turquoise m-4"
           onClick={handleSaveEdits}

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -166,30 +166,31 @@ const FlagDetailsPage = () => {
               <div className="inline-block w-1/2 text-right pr-10">
                 <button
                   type="button"
-                  className="text-sm border bg-primary-offwhite text-primary-oxfordblue p-1.5 mt-2 ml-6 rounded-lg hover:bg-primary-violet hover:text-primary-offwhite"
+                  className="text-sm border bg-primary-offwhite text-primary-oxfordblue p-1.5 my-2 ml-6 rounded-lg hover:bg-slate hover:text-primary-offwhite"
                   onClick={() => setShowCAssignments(true)}
                 >
                   Show Custom Assignments<FontAwesomeIcon icon={faCaretDown} className="ml-1" />
                 </button>
               </div>
-
             ) : (
               <>
-                <button
-                  type="button"
-                  className="inline-block w-1/2 text-right pr-10 text-primary-oxfordblue ml-6 hover:text-primary-violet"
-                  onClick={() => setShowCAssignments(false)}
-                >
-                  Hide Custom Assignments <FontAwesomeIcon icon={faCaretUp} />
-                </button>
+                <div className="block w-1/2 text-right pr-10">
+                  <button
+                    type="button"
+                    className="inline-block w-1/2 text-sm border bg-primary-offwhite text-primary-oxfordblue p-1.5 my-2 rounded-lg ml-6 hover:bg-slate hover:text-primary-offwhite"
+                    onClick={() => setShowCAssignments(false)}
+                  >
+                    Hide Custom Assignments <FontAwesomeIcon icon={faCaretUp} />
+                  </button>
+                </div>
                 <div className="inline-block w-1/2 text-right pr-10">Always on for user IDs:</div>
                 <span className="font-bold">{customAssignments.on.join(", ")}</span>
                 <div className="inline-block w-1/2 text-right pr-10">Always off for user IDs:</div>
                 <span className="font-bold">{customAssignments.off.join(", ")}</span>
               </>
             )}
-
-          </div>}
+          </div>
+          }
         </div>
       ) : (
         <EditFlagForm

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -163,13 +163,16 @@ const FlagDetailsPage = () => {
           {cAssignmentData &&
           <div>
             {!showCAssignments ? (
-              <button
-                type="button"
-                className="inline-block w-1/2 text-right pr-10 text-primary-oxfordblue ml-6 hover:text-primary-violet"
-                onClick={() => setShowCAssignments(true)}
-              >
-                Show Custom Assignments <FontAwesomeIcon icon={faCaretDown} />
-              </button>
+              <div className="inline-block w-1/2 text-right pr-10">
+                <button
+                  type="button"
+                  className="text-sm border bg-primary-offwhite text-primary-oxfordblue p-1.5 mt-2 ml-6 rounded-lg hover:bg-primary-violet hover:text-primary-offwhite"
+                  onClick={() => setShowCAssignments(true)}
+                >
+                  Show Custom Assignments<FontAwesomeIcon icon={faCaretDown} className="ml-1" />
+                </button>
+              </div>
+
             ) : (
               <>
                 <button

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,10 +5,10 @@ import App from './App';
 import store from './lib/Store'
 import { Provider } from 'react-redux'
 
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = require('./mocks/browser')
-  worker.start()
-}
+// if (process.env.NODE_ENV === 'development') {
+//   const { worker } = require('./mocks/browser')
+//   worker.start()
+// }
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
## Edit Flag Form
- Discussion for this was on Slack
- Added more margin between the form and the Submit buttons
- Changed design of the "delete" and "add" custom assignments buttons so that they are just bold with an underline. When hovered, a gray background will show, the underline will be removed, and the text will become darker.

Screenshot of the form while hovering over the "Delete" button:
![edit Flag](https://user-images.githubusercontent.com/75290988/159780152-3c3f2eda-c9b4-4c95-8919-5dea77f366b9.jpg)


## Flag Details Page
- Add border and background color on hover to the Show/Hide Custom Assignments button. Previously didn't look like a button you could press

### Screenshots:
Not hovering:
![default](https://user-images.githubusercontent.com/75290988/159779755-013e8d37-e5c0-412c-9cfb-2685b2edda78.jpg)
Hovering:
![Show on hover](https://user-images.githubusercontent.com/75290988/159779800-894a8f14-96dc-4e4d-93e9-7bd2db6cb30a.jpg)
Not hovering:
![showing](https://user-images.githubusercontent.com/75290988/159779846-10bfc428-08e5-416b-9401-de0f0a7649b2.jpg)
Hovering: 
![Hide on hover](https://user-images.githubusercontent.com/75290988/159779877-03d82063-7581-4166-aca8-b72439802064.jpg)


Please let me know if you want anything to look different, I'm open to ideas and happy to change anything.
