### PR TITLE
Bug fixes

### DIFF
--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -38,8 +38,9 @@ export function editExperimentSuccess(editedExpt) {
 
 export function updateStats(id) {
   return function(dispatch) {
-    apiClient.updateStats(id, data => {
-      dispatch(updateStatsSuccess(data));
+    return apiClient.updateStats(id, data => {
+      dispatch(updateStatsSuccess(data.stats));
+      return data.error_message;
     });
   }
 }

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -27,8 +27,7 @@ export function editExperiment(exptId, updatedFields) {
     return apiClient.editExperiment(exptId, updatedFields, data => {
       dispatch(updateStatsSuccess(data.stats));
       dispatch(editExperimentSuccess(data.updatedExpt));
-      return "Not connected to database, please connect and then try again for up to date results."
-      // return data.error_message
+      return data.error_message;
     });
   }
 }

--- a/client/src/actions/exptActions.js
+++ b/client/src/actions/exptActions.js
@@ -24,9 +24,11 @@ export function createExperimentSuccess(newExpt) {
 
 export function editExperiment(exptId, updatedFields) {
   return function(dispatch) {
-    apiClient.editExperiment(exptId, updatedFields, data => {
-      dispatch(updateStatsSuccess(data.stats))
+    return apiClient.editExperiment(exptId, updatedFields, data => {
+      dispatch(updateStatsSuccess(data.stats));
       dispatch(editExperimentSuccess(data.updatedExpt));
+      return "Not connected to database, please connect and then try again for up to date results."
+      // return data.error_message
     });
   }
 }

--- a/client/src/components/experiments/ExperimentResults.jsx
+++ b/client/src/components/experiments/ExperimentResults.jsx
@@ -8,8 +8,9 @@ const ExperimentResults = ({ id }) => {
   const hasResult = metrics.find(metric => metric.p_value !== null);
   const dispatch = useDispatch();
 
-  const handleRefreshResults = () => {
-    dispatch(updateStats(id));
+  const handleRefreshResults = async () => {
+    const err = await dispatch(updateStats(id));
+    if (err) alert(err);
   };
 
   return (

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -79,11 +79,12 @@ const FlagDetailsPage = () => {
     navigate(path);
   };
 
-  const handleStopExperiment = (e) => {
+  const handleStopExperiment = async (e) => {
     e.preventDefault();
     const runningExptId = exptData.find(expt => expt.date_ended === null).id;
     dispatch(editFlag(flagId, { is_experiment: false}));
-    dispatch(editExperiment(runningExptId, { date_ended: true}));
+    const err = await dispatch(editExperiment(runningExptId, { date_ended: true}));
+    if (err) alert(err);
   };
 
   const handleToggle = (id) => {

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -181,9 +181,13 @@ const FlagDetailsPage = () => {
                   Hide Custom Assignments <FontAwesomeIcon icon={faCaretUp} />
                 </button>
                 <div className="inline-block w-1/2 text-right pr-10">Always on for user IDs:</div>
-                <span className="font-bold">{customAssignments.on.join(", ")}</span>
+                <span className="font-bold">
+                  {customAssignments.on.length > 0 ? customAssignments.on.join(", ") : " "}
+                </span>
                 <div className="inline-block w-1/2 text-right pr-10">Always off for user IDs:</div>
-                <span className="font-bold">{customAssignments.off.join(", ")}</span>
+                <span className="font-bold">
+                  {customAssignments.off.length > 0 ? customAssignments.on.join(", ") : " "}
+                </span>
               </>
             )}
 

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -84,7 +84,7 @@ const FlagDetailsPage = () => {
     const runningExptId = exptData.find(expt => expt.date_ended === null).id;
     dispatch(editFlag(flagId, { is_experiment: false}));
     const err = await dispatch(editExperiment(runningExptId, { date_ended: true}));
-    if (err) alert(err);
+    if (err) alert(err + " Please connect and then try again for up-to-date results");
   };
 
   const handleToggle = (id) => {

--- a/client/src/components/pages/FlagDetailsPage.jsx
+++ b/client/src/components/pages/FlagDetailsPage.jsx
@@ -84,7 +84,7 @@ const FlagDetailsPage = () => {
     const runningExptId = exptData.find(expt => expt.date_ended === null).id;
     dispatch(editFlag(flagId, { is_experiment: false}));
     const err = await dispatch(editExperiment(runningExptId, { date_ended: true}));
-    if (err) alert(err + " Please connect and then try again for up-to-date results");
+    if (err) alert(err);
   };
 
   const handleToggle = (id) => {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,10 +5,10 @@ import App from './App';
 import store from './lib/Store'
 import { Provider } from 'react-redux'
 
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = require('./mocks/browser')
-  worker.start()
-}
+// if (process.env.NODE_ENV === 'development') {
+//   const { worker } = require('./mocks/browser')
+//   worker.start()
+// }
 
 ReactDOM.render(
   <Provider store={store}>

--- a/client/src/reducers/customAssignments.js
+++ b/client/src/reducers/customAssignments.js
@@ -23,7 +23,11 @@ export default function customAssignments(state = {}, action) {
     case "CREATED_ASSIGNMENTS_SUCCESS": {
       const newState = JSON.parse(JSON.stringify(state));
       Object.keys(action.newAssignments).forEach((flagId) => {
-        Object.assign(newState[flagId], action.newAssignments[flagId]);
+        if (newState[flagId]) {
+          Object.assign(newState[flagId], action.newAssignments[flagId]);
+        } else {
+          newState[flagId] = action.newAssignments[flagId];
+        }
       })
       return newState;
     }

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -197,14 +197,22 @@ const analyzeAll = async (req, res, next) => {
 
 const analyzeExperiment = async (req, res, next) => {
   const id = req.params.id;
+  const returnObj = req.updatedExpt ? { updatedExpt: req.updatedExpt } : {};
   try {
     await runAnalytics(id);
+  } catch (e) {
+    returnObj.error_message = "Not connected to event database";
+  }
+
+  try {
     const result = await experimentsTable.query(GET_METRIC_DATA, [ id ]);
-    if (req.updatedExpt) {
-      res.status(200).send({ stats: result.rows, updatedExpt: req.updatedExpt });
-    } else {
-      res.status(200).send(result.rows)
-    }
+    returnObj.stats = result.rows;
+    res.status(200).send(returnObj);
+    // if (req.updatedExpt) {
+    //   res.status(200).send({ stats: result.rows, updatedExpt: req.updatedExpt });
+    // } else {
+    //   res.status(200).send(result.rows)
+    // }
   } catch (err) {
     console.log(err);
     res.status(500).send(err.message);

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -201,7 +201,8 @@ const analyzeExperiment = async (req, res, next) => {
   try {
     await runAnalytics(id);
   } catch (e) {
-    returnObj.error_message = "Not connected to event database";
+    const errMessage = "Not connected to event database. Please connect and try again for up-to-date results";
+    returnObj.error_message = errMessage;
   }
 
   try {

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -209,11 +209,6 @@ const analyzeExperiment = async (req, res, next) => {
     const result = await experimentsTable.query(GET_METRIC_DATA, [ id ]);
     returnObj.stats = result.rows;
     res.status(200).send(returnObj);
-    // if (req.updatedExpt) {
-    //   res.status(200).send({ stats: result.rows, updatedExpt: req.updatedExpt });
-    // } else {
-    //   res.status(200).send(result.rows)
-    // }
   } catch (err) {
     console.log(err);
     res.status(500).send(err.message);

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -52,7 +52,6 @@ const getAllFlags = async (req, res, next) => {
 
 const setFlagsOnReq = async (req, res, next) => {
   const data = await getFlagsForWebhook();
-  console.log(data);
   req.flags = data;
   next();
 };

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -81,7 +81,6 @@ const createFlag = async (req, res, next) => {
       const savedFlag = await flagTable.insertRow(newFlag);
 
       req.eventType = "FLAG_CREATED";
-      req.flagId = savedFlag.
 
       res.status(200).send(savedFlag);
       next();


### PR DESCRIPTION
### Error when running `runAnalysis` when not connected to events DB
- When we clicked "stop experiment" or "refresh data" it ran `runAnalytics`, which tries to connect to event DB to get the data, and throws an error if it can't connect.
- To fix this I altered `experimentController.editExperiment`, wrapping the `runAnalytics` call in a try catch block.
  - I created a return object at beginning of `runAnalysis`, and if an error was thrown, it was caught and an error message was attached to the return object. 
  - I also attached the `stats` and `updatedExpt` to this `returnObj`
- On the front-end, I returned the error message from the `updateStats` and `editExperiment` actions
  -  In the `handleStopExperiment` and `handleRefreshResults` I assigned this error message to a variable, and if the variable returns true (it returns `undefined` when we're connected to the DB), it alerts the user of the problem.

### Error with adding custom assignment to flag with none previously
- The problem arose in the "CREATED_ASSIGNMENTS_SUCCESS" case in the `customAssignment` reducer. I was calling `Object.assign` on an object that didn't exist yet. I added an if else to check whether the object exists, and if it doesn't, then I just set the state to the new assignments.
- There was a CSS bug on `FlagDetailsPage` where if I didn't have any custom assignments in the "Always On" category, "Always On" and "Always Off" appeared on the same line. I edited the `<span>` that this data was displayed in to contain a space `" "` in the case that there are no custom assignments for a group.

### flagsController.createFlag error in backend
- There was a line with a small typo. I removed that line.