### PR TITLE
Added error message handling to runAnalysis and getFlagsForWebhook bug

### DIFF
--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -153,7 +153,7 @@ const analyzeExperiment = async (req, res, next) => {
       returnObj.error_message = e.message;
     } else {
       const errMessage =
-      "Not connected to event database. Please connect and try again for up-to-date results";
+        "Not connected to event database. Please connect and try again for up-to-date results";
       returnObj.error_message = errMessage;
     }
   }

--- a/server/controllers/experimentController.js
+++ b/server/controllers/experimentController.js
@@ -149,9 +149,13 @@ const analyzeExperiment = async (req, res, next) => {
   try {
     await runAnalytics(id);
   } catch (e) {
-    const errMessage =
+    if (e.message === "Sample size too small") {
+      returnObj.error_message = e.message;
+    } else {
+      const errMessage =
       "Not connected to event database. Please connect and try again for up-to-date results";
-    returnObj.error_message = errMessage;
+      returnObj.error_message = errMessage;
+    }
   }
 
   try {

--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -33,6 +33,11 @@ const createNewFlagObj = ({
   };
 };
 
+const getFlagsForWebhook = async () => {
+  const result = await flagTable.query(GET_FLAGS_FOR_WEBHOOK);
+  return result.rows[0] === undefined ? undefined : result.rows;
+}
+
 const getAllFlags = async (req, res, next) => {
   let data;
   try {
@@ -55,8 +60,7 @@ const getAllFlags = async (req, res, next) => {
 };
 
 const setFlagsOnReq = async (req, res, next) => {
-  const result = await flagTable.query(GET_FLAGS_FOR_WEBHOOK);
-  const data = result.rows[0] === undefined ? undefined : result.rows;
+  const data = await getFlagsForWebhook()
   req.flags = data;
   next();
 };

--- a/server/lib/statistics.js
+++ b/server/lib/statistics.js
@@ -116,7 +116,6 @@ const calcDiscreteMetric = async (exptId, metricId, exptQuery, metricQuery) => {
     obs.push(data);
   });
   const stat = chi2test(obs);
-
   // Insert into experiment_metrics table
   const insertStatement = `
     UPDATE experiment_metrics


### PR DESCRIPTION
Was getting this message when I created a new experiment and hit "Refresh results" or "Stop experiment", even when I was connected to the DB.
![image](https://user-images.githubusercontent.com/59182147/160003796-207ed924-16cf-402e-86e2-cae2e6d5fac5.png)

It was happening because `runAnalysis` was throwing an error when the sample size was too small, and the current error message was being used for all errors, not just when the sample size was too small. Added conditional logic to show proper error messages.

Recreated `getFlagsForWebhook` in the flagsController and made calls to it in `getAllFlags` and `setFlagsOnReq`.