### PR TITLE
Add custom assignments to flags data when provider sends GET request

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -9,7 +9,7 @@ flagTable.init();
 const GET_FLAGS_FOR_WEBHOOK = `
   SELECT id, name, status, percentage_split, hash_offset, is_experiment
   FROM flags
-  WHERE is_deleted=false
+  WHERE is_deleted = FALSE
 `;
 
 const createNewFlagObj = ({
@@ -42,7 +42,7 @@ const getAllFlags = async (req, res, next) => {
   let data;
   try {
     if (req.query.prov) {
-      data = await getFlagsForWebhook();
+      next();
     } else {
       data = await flagTable.getAllRowsNotDeleted();
 
@@ -142,6 +142,7 @@ const sendFlagsWebhook = async (req, res, next) => {
   } catch (err) {
     console.log(err.message);
   }
+  if (req.query.prov) return;
   next();
 };
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -10,7 +10,12 @@ const logsController = require("../controllers/logsController");
 const cAssignmentController = require("../controllers/cAssignmentController");
 
 // -------- Flags --------
-router.get("/flags", flagsController.getAllFlags);
+router.get("/flags",
+  flagsController.getAllFlags,
+  flagsController.setFlagsOnReq,
+  cAssignmentController.setAssignmentsOnEachFlag,
+  flagsController.sendFlagsWebhook
+);
 
 router.get("/flags/:id", flagsController.getFlag);
 


### PR DESCRIPTION
Had to add middleware to the GET /flags API endpoint so that custom assignments are added onto the flag objects. Also since there's no logging for GET requests, I had to make the last one (`sendFlagsWebhook`) return instead of calling `next()` since there's no more middleware for this route.