### PR TITLE
Altered GET /flags so it sends flags back to Provider with empty DB

### DIFF
--- a/server/controllers/flagsController.js
+++ b/server/controllers/flagsController.js
@@ -35,22 +35,22 @@ const createNewFlagObj = ({
 
 const getFlagsForWebhook = async () => {
   const result = await flagTable.query(GET_FLAGS_FOR_WEBHOOK);
-  return result.rows[0] === undefined ? undefined : result.rows;
+  return result.rows[0] === undefined ? [] : result.rows;
 }
 
 const getAllFlags = async (req, res, next) => {
-  let data;
-  try {
-    if (req.query.prov) {
-      next();
-    } else {
-      data = await flagTable.getAllRowsNotDeleted();
+  if (req.query.prov) {
+    next();
+    return;
+  }
 
-      if (!data) {
-        throw new Error(
-          `Data could not be retreived from the ${flagTable.tableName} table`
-        );
-      }
+  try {
+    const data = await flagTable.getAllRowsNotDeleted();
+
+    if (!data) {
+      throw new Error(
+        `Data could not be retreived from the ${flagTable.tableName} table`
+      );
     }
 
     res.status(200).send(data);
@@ -58,6 +58,10 @@ const getAllFlags = async (req, res, next) => {
     res.status(500).send(e.message);
   }
 };
+
+const sendFlagsOnReq = (req, res, next) => {
+  res.status(200).send(req.flags);
+}
 
 const setFlagsOnReq = async (req, res, next) => {
   const data = await getFlagsForWebhook()
@@ -154,3 +158,4 @@ exports.deleteFlag = deleteFlag;
 exports.getFlag = getFlag;
 exports.setFlagsOnReq = setFlagsOnReq;
 exports.sendFlagsWebhook = sendFlagsWebhook;
+exports.sendFlagsOnReq = sendFlagsOnReq;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -14,7 +14,7 @@ router.get("/flags",
   flagsController.getAllFlags,
   flagsController.setFlagsOnReq,
   cAssignmentController.setAssignmentsOnEachFlag,
-  flagsController.sendFlagsWebhook
+  flagsController.sendFlagsOnReq
 );
 
 router.get("/flags/:id", flagsController.getFlag);


### PR DESCRIPTION
Before, data was getting sent back to Provider from `flagsController.getAllFlags`, then the middleware was invoked and it ran into an error, sending back an additional response, calling this error. This error was caused by `req.flags` being set to `undefined` as a result of `getFlagsForWebhook` returning `undefined`, then `.forEach` being called on `undefined.

To fix this:
- I made `getFlagsForWebhook` return an empty array when there are no flags in the DB.
- I made `getAllFlags` return after calling `next()` when `req.query.prov === true`

We were also setting `this._flags` in the provider whatever was returned by Waypost, then sending a webhook from Waypost which set the `this._flags` variable again. This was unnecessary, so I changed Waypost to not send the webhook on GET /flags and replaced the middleware with a `sendFlagsOnReq` which simply sends 200 and req.flags.